### PR TITLE
Remove history entries that were doubling up what `bornHuman` adds

### DIFF
--- a/assets/data/history/drauvenBase.json
+++ b/assets/data/history/drauvenBase.json
@@ -1,63 +1,10 @@
 [
 {
-	"id": "500",
+	"id": "default",
 	"weight": 0.95,
 	"category": "bornDrauven",
-	"forbiddenAspects": [ "female", "attractedToMen" ],
-	"impliedAspects": [ "male", "drauvenMale", "maleBody", "heterosexual", "attractedToWomen" ],
 	"humanName": "drauvenName",
 	"showInSummary": false
-},
-{
-	"id": "501",
-	"weight": 0.03,
-	"category": "bornDrauven",
-	"forbiddenAspects": [ "female", "attractedToWomen" ],
-	"impliedAspects": [ "male", "drauvenMale", "maleBody", "gay", "attractedToMen" ],
-	"humanName": "drauvenName",
-	"showInSummary": false
-},
-{
-	"id": "502",
-	"weight": 0.95,
-	"category": "bornDrauven",
-	"forbiddenAspects": [ "male", "attractedToWomen" ],
-	"impliedAspects": [ "female", "drauvenFemale", "femaleBody", "heterosexual", "attractedToMen" ],
-	"humanName": "drauvenName",
-	"showInSummary": false
-},
-{
-	"id": "503",
-	"weight": 0.03,
-	"category": "bornDrauven",
-	"forbiddenAspects": [ "male", "attractedToMen" ],
-	"impliedAspects": [ "female", "drauvenFemale", "femaleBody", "gay", "attractedToWomen" ],
-	"humanName": "drauvenName",
-	"showInSummary": false
-},
-{
-	"id": "504",
-	"weight": 0.04,
-	"category": "bornDrauven",
-	"forbiddenAspects": [ "female" ],
-	"impliedAspects": [ "male", "drauvenMale", "maleBody", "attractedToMen", "attractedToWomen" ],
-	"humanName": "drauvenName",
-	"showInSummary": false
-},
-{
-	"id": "505",
-	"weight": 0.04,
-	"category": "bornDrauven",
-	"forbiddenAspects": [ "male" ],
-	"impliedAspects": [ "female", "drauvenFemale", "femaleBody", "attractedToMen", "attractedToWomen" ],
-	"humanName": "drauvenName",
-	"showInSummary": false
-},
-{
-	"id": "709",
-	"category": "dieOfOldAge",
-	"impliedAspects": [ "dead" ],
-	"removeAspects": [ "alive", "activeDefender" ]
 },
 {
 	"id": "701",


### PR DESCRIPTION
* Since switching to use the `human` tag as our base, characters were getting both `bornHuman` and `bornDrauven`, resulting in characters possibly being tagged as both male and female
* Removed duplicated aspects from `bornDrauven` so that we're only worried about the unique drauv aspects (currently just setting the `drauvenName`)

Note: This may be a breaking change for characters that have already been generated.