### PR TITLE
Update the drauv-assist event to remove the badly generated deeven

### DIFF
--- a/assets/data/effects/arriveAtSite/drauven_pcs_test_dEVTESTDefendDrauvfromGorgons.json
+++ b/assets/data/effects/arriveAtSite/drauven_pcs_test_dEVTESTDefendDrauvfromGorgons.json
@@ -57,7 +57,7 @@
 							"size": 0.523
 						},
 						{
-							"role": "npc3",
+							"role": "npc2",
 							"facing": "left",
 							"equipment": {},
 							"focus": "foot",
@@ -84,7 +84,7 @@
 		"combatants": [
 			{ "role": "party", "side": "player" },
 			{
-				"roles": [ "npc", "npc2", "npc3" ],
+				"roles": [ "npc", "npc2" ],
 				"side": "player"
 			},
 			{
@@ -107,7 +107,7 @@
 		{
 			"npcId": "drauvDefender1",
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "mystic" },
+				"query": { "baseTag": "human", "setClass": "nonFarmer" },
 				"control": "none",
 				"additionalOutcome": {
 					"class": "DoAll",
@@ -132,7 +132,7 @@
 			"role": "npc2",
 			"npcId": "drauvDefender2",
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "mystic" },
+				"query": { "baseTag": "human", "setClass": "nonFarmer" },
 				"control": "none",
 				"additionalOutcome": {
 					"class": "DoAll",
@@ -151,13 +151,6 @@
 						{ "class": "ApplyTheme", "target": "npc2", "theme": "drauven", "piece": "torso" }
 					]
 				}
-			}
-		},
-		{
-			"role": "npc3",
-			"createEntity": {
-				"query": { "baseTag": "drauven_skysinger" },
-				"control": "none"
 			}
 		}
 	]

--- a/assets/text/effects/arriveAtSite/drauven_pcs_test_dEVTESTDefendDrauvfromGorgons_en_GB.properties
+++ b/assets/text/effects/arriveAtSite/drauven_pcs_test_dEVTESTDefendDrauvfromGorgons_en_GB.properties
@@ -1,3 +1,3 @@
 #suppress inspection "UnusedProperty" for whole file
-~01~~panel_001~1_npc=We are under attack! Help us stave off the gorgons!
+~01~~panel_001~1_npc=We are under attack! Help us fend off the gorgons!
 ~01~~panel_001~1_npc~TWEAK={padXFraction:0.383,padYFraction:0.057}


### PR DESCRIPTION
* Also reverts the event to generating 2 random-class drauven NPCs
* Still needs a proper comic and follow-up with a choice to recruit one of the named NPCs

Closes #32 