### PR TITLE
Hotfix for "Abandoned No Longer"

### DIFF
--- a/assets/data/aspects/drauvenRelationships.json
+++ b/assets/data/aspects/drauvenRelationships.json
@@ -1,14 +1,18 @@
 [
   {
-    "id": "drauvenHealer"
+    "id": "drauvenHealer",
+    "lifespan": "all"
   },
   {
-    "id": "drauvenHealer_sawTiding"
+    "id": "drauvenHealer_sawTiding",
+    "lifespan": "all"
   },
   {
-    "id": "drauvenSkeptic"
+    "id": "drauvenSkeptic",
+    "lifespan": "all"
   },
   {
-    "id": "killedAbandonedDrauven"
+    "id": "killedAbandonedDrauven",
+    "lifespan": "all"
   }
 ]

--- a/assets/data/effects/abandonedNoLonger.json
+++ b/assets/data/effects/abandonedNoLonger.json
@@ -13,7 +13,8 @@
 	"category": "attack",
 	"priority": "1",
 	"cooldown": "oncePerGame",
-	"encounterScore": 100,
+	"encounterScore": 1,
+	"encounterWeight": "0",
 	"encounterEnabled": true,
 	"musicOverride": "Music/Comics - Tragic-Sympathetic NPC"
 },
@@ -42,7 +43,7 @@
 		"role": "healer",
 		"template": "PICK_BY_SCORE",
 		"type": "HERO",
-		"scoreFunction": "drauvenHealer+alive",
+		"scoreFunction": "drauvenHealer_sawTiding+alive",
 		"scoreThreshold": "2",
 		"notAlreadyMatchedAs": []
 	},
@@ -52,7 +53,6 @@
 		"type": "HERO",
 		"choose": "BY_SCORE_OPTIONAL",
 		"scoreFunction": null,
-		"aspects": null,
 		"notAlreadyMatchedAs": [ "healer" ]
 	},
 	{

--- a/assets/text/effects/abandonedNoLonger.properties
+++ b/assets/text/effects/abandonedNoLonger.properties
@@ -5,6 +5,6 @@
 ~01~prompt~panel_003~1_healer=What are you going to do now?
 ~02~choice_two~panel_001~1_npc=<npc> comes with yew!
 ~02~choice_two~panel_001~2_narration=Cost: 2LP
-~03~choice_one~panel_001~1_healer=No, Drana needs to stay here and live a good life.
+~03~choice_one~panel_001~1_healer=No, <npc> needs to stay here and live a good life.
 ~04~player_chose_one~panel_001~1_healer=Stay safe and be well, <npc>. I want you to live a long and happy life.
 ~05~player_chose_two~panel_001~1_npc=<npc> ows yew <npc.mf:his/her/their> life. Mebbe <npc> will save <healer> someday!


### PR DESCRIPTION
* Fix event being able to fire without the preceeding event
* Fix accidental hardcoded NPC name in abandoned-no-longer
* Set drauven relationship aspects to not expire