### PR TITLE
Legacy bug fix

### DIFF
--- a/assets/data/aspects/drauvenAging.json
+++ b/assets/data/aspects/drauvenAging.json
@@ -1,139 +1,126 @@
 [
-{ "modId": "wildermyth-drauven-pcs", "id": "drauven_ageless", "lifespan": "all" },
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_ageless",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_armour",
+	"stats": { "ARMOR": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_block",
+	"stats": { "BLOCK": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_charisma",
+	"stats": { "CHARISMA": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_charisma_penalty",
+	"stats": { "CHARISMA": -1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_dodge",
+	"stats": { "DODGE": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_dodge_penalty",
+	"stats": { "DODGE": -1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_health",
+	"stats": { "HEALTH": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_perception",
+	"stats": { "PERCEPTION": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_perception_penalty",
+	"stats": { "PERCEPTION": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_recovery",
+	"stats": { "RECOVERY_RATE": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_speed",
+	"stats": { "SPEED": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_speed_penalty",
+	"stats": { "SPEED": -1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_tenacity",
+	"stats": { "TENACITY": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_aging_warding",
+	"stats": { "WARDING": 1 },
+	"importance": -1,
+	"showChangeInComics": "never",
+	"lifespan": "all"
+},
 {
 	"modId": "wildermyth-drauven-pcs",
 	"id": "drauven_cannotAge",
 	"lifespan": "all"
 },
-
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_armour",
-	"lifespan": "all",
-	"stats": {
-		"ARMOR": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_warding",
-	"lifespan": "all",
-	"stats": {
-		"WARDING": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_speed",
-	"lifespan": "all",
-	"stats": {
-		"SPEED": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_speed_penalty",
-	"lifespan": "all",
-	"stats": {
-		"SPEED": -1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_charisma",
-	"lifespan": "all",
-	"stats": {
-		"CHARISMA": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_charisma_penalty",
-	"lifespan": "all",
-	"stats": {
-		"CHARISMA": -1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_tenacity",
-	"lifespan": "all",
-	"stats": {
-		"TENACITY": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_block",
-	"lifespan": "all",
-	"stats": {
-		"BLOCK": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_dodge",
-	"lifespan": "all",
-	"stats": {
-		"DODGE": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_dodge_penalty",
-	"lifespan": "all",
-	"stats": {
-		"DODGE": -1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_health",
-	"lifespan": "all",
-	"stats": {
-		"HEALTH": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_perception",
-	"lifespan": "all",
-	"stats": {
-		"PERCEPTION": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_perception_penalty",
-	"lifespan": "all",
-	"stats": {
-		"PERCEPTION": 1.0
-	},
-	"importance": -1
-},
-{ 
-	"modId": "wildermyth-drauven-pcs",
-	"id": "drauven_aging_recovery",
-	"lifespan": "all",
-	"stats": {
-		"RECOVERY_RATE": 1.0
-	},
-	"importance": -1
-},
-
-
 {
 	"modId": "wildermyth-drauven-pcs",
 	"id": "random_spawn_wound",

--- a/assets/data/aspects/drauven_init.json
+++ b/assets/data/aspects/drauven_init.json
@@ -1,0 +1,11 @@
+[
+{
+	"modId": "wildermyth-drauven-pcs-main",
+	"id": "drauven_pc_init_asp",
+	"effects": [ "drauven_pc_init" ],
+	"importance": -1,
+	"showChangeInComics": "never",
+	"invalidatesSkin": true,
+	"lifespan": "all"
+}
+]

--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
@@ -3,7 +3,7 @@
 "info": {
 	"dataVersion": 1,
 	"sourceFile": "arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit",
-	"modId": "wildermyth-drauven-pcs",
+	"modId": "wildermyth-drauven-pcs-main",
 	"author": "Ironskink"
 },
 "type": "ENCOUNTER_HEROES_ARRIVE_HOSTILE_SITE",
@@ -27,7 +27,6 @@
 		"type": "HERO",
 		"scoreFunction": "drauven_pc",
 		"scoreThreshold": "1",
-		"aspects": null,
 		"notAlreadyMatchedAs": []
 	},
 	{
@@ -407,69 +406,30 @@
 		{
 			"createEntity": {
 				"query": { "baseTag": "human", "setClass": "warrior" },
-				"control": "none",
-				"additionalOutcome": {
-					"class": "DoAll",
-					"outcomes": [
-						{
-							"class": "AddHistory",
-							"addHistory": [
-								[ "drauvenBase" ],
-								[ "bornDrauven" ],
-								[ "drauvenCustomizationHead" ],
-								[ "drauvenCustomizationBody" ],
-								[ "drauvenCustomizationOther" ]
-							]
-						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" }
-					]
-				}
+				"addAspects": [
+					{ "id": "drauven_pc_init", "value": "1" }
+				],
+				"control": "none"
 			}
 		},
 		{
 			"role": "npc2",
 			"createEntity": {
 				"query": { "baseTag": "human", "setClass": "hunter" },
-				"control": "none",
-				"additionalOutcome": {
-					"class": "DoAll",
-					"outcomes": [
-						{
-							"class": "AddHistory",
-							"addHistory": [
-								[ "drauvenBase" ],
-								[ "bornDrauven" ],
-								[ "drauvenCustomizationHead" ],
-								[ "drauvenCustomizationBody" ],
-								[ "drauvenCustomizationOther" ]
-							]
-						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" }
-					]
-				}
+				"addAspects": [
+					{ "id": "drauven_pc_init", "value": "1" }
+				],
+				"control": "none"
 			}
 		},
 		{
 			"role": "npc3",
 			"createEntity": {
 				"query": { "baseTag": "human", "setClass": "mystic" },
-				"control": "none",
-				"additionalOutcome": {
-					"class": "DoAll",
-					"outcomes": [
-						{
-							"class": "AddHistory",
-							"addHistory": [
-								[ "drauvenBase" ],
-								[ "bornDrauven" ],
-								[ "drauvenCustomizationHead" ],
-								[ "drauvenCustomizationBody" ],
-								[ "drauvenCustomizationOther" ]
-							]
-						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" }
-					]
-				}
+				"addAspects": [
+					{ "id": "drauven_pc_init", "value": "1" }
+				],
+				"control": "none"
 			}
 		}
 	]

--- a/assets/data/effects/drauven_pc_init.json
+++ b/assets/data/effects/drauven_pc_init.json
@@ -1,0 +1,67 @@
+{
+"id": "drauven_pc_init",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "drauven_pc_init",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess & Ironskink",
+	"STUB": "Initialize our Drauven characters"
+},
+"type": "ABILITIES_CHANGED",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "AddHistory",
+		"target": "self",
+		"addHistory": [
+			[ "drauvenBase" ],
+			[ "bornDrauven" ],
+			[ "drauvenCustomizationBody" ],
+			[ "drauvenCustomizationOther" ]
+		]
+	},
+	{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
+	{
+		"class": "Test",
+		"value": "self.warrior",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"target": "self",
+			"addHistory": [
+				[ "drauvenCustomizationHead_warrior" ]
+			]
+		}
+	},
+	{
+		"class": "Test",
+		"value": "self.hunter",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"target": "self",
+			"addHistory": [
+				[ "drauvenCustomizationHead_hunter" ]
+			]
+		}
+	},
+	{
+		"class": "Test",
+		"value": "self.mystic",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"target": "self",
+			"addHistory": [
+				[ "drauvenCustomizationHead_mystic" ]
+			]
+		}
+	},
+	{
+		"class": "Aspects",
+		"removeAspects": [ "drauven_pc_init" ]
+	}
+]
+}

--- a/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
+++ b/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
@@ -1,0 +1,79 @@
+{
+"id": "wildermyth-drauven-pcs-main_heyItsaNewDrauv",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "wildermyth-drauven-pcs-main_heyItsaNewDrauv",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess"
+},
+"type": "ENCOUNTER_HEROES_ARRIVE_HOSTILE_SITE",
+"verb": "MANEUVER",
+"ability": {
+	"icon": "melee",
+	"priority": "1",
+	"cooldown": "oncePerGame",
+	"encounterScore": 20,
+	"encounterWeight": "1"
+},
+"targets": [
+	{ "template": "EVENT" },
+	{ "template": "COMPANY" },
+	{ "template": "INJECTED_TILE" },
+	{ "template": "INJECTED_SITE" },
+	{ "template": "INJECTED_PARTY" },
+	{ "template": "INJECTED_THREAT" }
+],
+"outcomes": [
+	{
+		"class": "Description",
+		"script": [
+			{
+				"class": "comicNode_Panel",
+				"panel": {
+					"size": "full",
+					"actorSlots": [
+						{
+							"role": "npc",
+							"equipment": {}
+						}
+					],
+					"textSlots": [
+						{
+							"textSourceFile": "wildermyth-drauven-pcs-main_heyItsaNewDrauv",
+							"textKey": "~01~~panel_001~1_narration",
+							"style": "narration"
+						}
+					]
+				}
+			}
+		]
+	},
+	{
+		"class": "Mission",
+		"goal": "liberate",
+		"combatants": [
+			{ "role": "party", "side": "player" },
+			{ "role": "foes", "side": "enemy" }
+		]
+	},
+	{
+		"class": "ChangeControl",
+		"target": "npc",
+		"becomeAllyOf": "party",
+		"makeHero": true
+	}
+],
+"implications": {
+	"generatedTargets": [
+		{
+			"createEntity": {
+				"query": { "baseTag": "human", "setClass": "nonFarmer" },
+				"addAspects": [
+					{ "id": "drauven_pc_init", "value": "1" }
+				],
+				"control": "none"
+			}
+		}
+	]
+}
+}

--- a/assets/data/effects/wilderness/theAbandoned.json
+++ b/assets/data/effects/wilderness/theAbandoned.json
@@ -3,7 +3,7 @@
 "info": {
 	"dataVersion": 1,
 	"sourceFile": "wilderness/theAbandoned",
-	"modId": "wildermyth-drauven-pcs",
+	"modId": "wildermyth-drauven-pcs-main",
 	"author": "Jeremy Bernstein"
 },
 "type": "ENCOUNTER_WILDERNESS_SCOUTING",
@@ -3590,23 +3590,19 @@
 					"setClass": "nonFarmer",
 					"exactAge": 8
 				},
+				"addAspects": [
+					{ "id": "drauven_pc_init", "value": "1" }
+				],
 				"control": "none",
 				"additionalOutcome": {
 					"class": "DoAll",
 					"outcomes": [
 						{
 							"class": "AddHistory",
-							"target": "npc",
 							"addHistory": [
-								[ "drauvenCustomizationHead" ],
-								[ "drauvenBase" ],
-								[ "bornDrauven" ],
-								[ "drauvenCustomizationBody" ],
-								[ "drauvenCustomizationOther" ],
-								[ "abandonedDrauven" ]
+								["abandonedDrauven"]
 							]
-						},
-						{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "torso" }
+						}
 					]
 				},
 				"placeOnMap": false

--- a/assets/data/history/drauvenBase.json
+++ b/assets/data/history/drauvenBase.json
@@ -240,4 +240,296 @@
 	],
 	"showInSummary": false
 }
+
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.1___",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior1"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head._2__",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior2"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.__3_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior3"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.___4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.12__",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior2"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.1_3_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior3"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.1__4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head._23_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior3"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head._2_4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.__34",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_warrior3", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.123_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior3"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.12_4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.1_34",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior3", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head._234",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior3", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.1234",
+	"weight": 0.1,
+	"impliedAspects": ["drauvenHeadCustom_warrior1", "drauvenHeadCustom_warrior2", "drauvenHeadCustom_warrior3", "drauvenHeadCustom_warrior4"]
+},
+{
+	"category": "drauvenCustomizationHead_warrior",
+	"id": "drauvenCustomWarrior.Head.____",
+	"weight": 0.1,
+	"impliedAspects": []
+},
+
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.1___",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter1"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head._2__",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter2"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.__3_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter3"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.___4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.12__",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter2"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.1_3_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter3"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.1__4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head._23_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter3"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head._2_4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.__34",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_hunter3", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.123_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter3"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.12_4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.1_34",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter3", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head._234",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter3", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.1234",
+	"weight": 0.1,
+	"impliedAspects": ["drauvenHeadCustom_hunter1", "drauvenHeadCustom_hunter2", "drauvenHeadCustom_hunter3", "drauvenHeadCustom_hunter4"]
+},
+{
+	"category": "drauvenCustomizationHead_hunter",
+	"id": "drauvenCustomHunter.Head.____",
+	"weight": 0.1,
+	"impliedAspects": []
+},
+
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.1___",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic1"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head._2__",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic2"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.__3_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic3"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.___4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.12__",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic2"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.1_3_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic3"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.1__4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head._23_",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic3"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head._2_4",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.__34",
+	"weight": 0.35,
+	"impliedAspects": ["drauvenHeadCustom_mystic3", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.123_",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic3"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.12_4",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.1_34",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic3", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head._234",
+	"weight": 0.2,
+	"impliedAspects": ["drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic3", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.1234",
+	"weight": 0.1,
+	"impliedAspects": ["drauvenHeadCustom_mystic1", "drauvenHeadCustom_mystic2", "drauvenHeadCustom_mystic3", "drauvenHeadCustom_mystic4"]
+},
+{
+	"category": "drauvenCustomizationHead_mystic",
+	"id": "drauvenCustomMystic.Head.____",
+	"weight": 0.1,
+	"impliedAspects": []
+}
+
 ]

--- a/assets/text/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.properties
+++ b/assets/text/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.properties
@@ -1,0 +1,4 @@
+#suppress inspection "UnusedProperty" for whole file
+.longName=Hey It's a New Drauv
+.name=
+~01~~panel_001~1_narration=Arriving at <site>


### PR DESCRIPTION
Overhauls how we create Drauven NPCs so that we can set it all up with a single aspect

* Makes facial details permanent through tying them directly to a History entry
* Adds `drauven_pc_init` as an aspect and effect to automate creating Drauven NPCs/PCs

Closes #50 