### PR TITLE
Update legacy characters

### DIFF
--- a/assets/data/aspects/drauvenCustomization.json
+++ b/assets/data/aspects/drauvenCustomization.json
@@ -1,34 +1,22 @@
 [
-    {
-        "id": "drauvenHeadCustomization1",
-        "effects": [
-            "alsoAddIfOther|drauvenHeadCustom_warrior1|warrior",
-            "alsoAddIfOther|drauvenHeadCustom_hunter1|hunter",
-            "alsoAddIfOther|drauvenHeadCustom_mystic1|mystic"
-        ]
-    },
-    {
-        "id": "drauvenHeadCustomization2",
-        "effects": [
-            "alsoAddIfOther|drauvenHeadCustom_warrior2|warrior",
-            "alsoAddIfOther|drauvenHeadCustom_hunter2|hunter",
-            "alsoAddIfOther|drauvenHeadCustom_mystic2|mystic"
-        ]
-    },
-    {
-        "id": "drauvenHeadCustomization3",
-        "effects": [
-            "alsoAddIfOther|drauvenHeadCustom_warrior3|warrior",
-            "alsoAddIfOther|drauvenHeadCustom_hunter3|hunter",
-            "alsoAddIfOther|drauvenHeadCustom_mystic3|mystic"
-        ]
-    },
-    {
-        "id": "drauvenHeadCustomization4",
-        "effects": [
-            "alsoAddIfOther|drauvenHeadCustom_warrior4|warrior",
-            "alsoAddIfOther|drauvenHeadCustom_hunter4|hunter",
-            "alsoAddIfOther|drauvenHeadCustom_mystic4|mystic"
-        ]
-    }
+{
+	"modId": "wildermyth-drauven-pcs-main",
+	"id": "drauvenHeadCustomization1",
+	"effects": [ "drauven_fix_customization_head1" ]
+},
+{
+	"modId": "wildermyth-drauven-pcs-main",
+	"id": "drauvenHeadCustomization2",
+	"effects": [ "drauven_fix_customization_head2" ]
+},
+{
+	"modId": "wildermyth-drauven-pcs-main",
+	"id": "drauvenHeadCustomization3",
+	"effects": [ "drauven_fix_customization_head3" ]
+},
+{
+	"modId": "wildermyth-drauven-pcs-main",
+	"id": "drauvenHeadCustomization4",
+	"effects": [ "drauven_fix_customization_head4" ]
+}
 ]

--- a/assets/data/effects/drauven_fix_customization_head1.json
+++ b/assets/data/effects/drauven_fix_customization_head1.json
@@ -1,0 +1,59 @@
+{
+"id": "drauven_fix_customization_head1",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "drauven_fix_customization_head1",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess",
+	"STUB": "Updates Drauven characters to our new system"
+},
+"type": "ABILITIES_CHANGED",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "Test",
+		"value": "warrior",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_warrior.detail1",
+				"associatedAspects": [ "drauvenHeadCustom_warrior1" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "hunter",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_hunter.detail1",
+				"associatedAspects": [ "drauvenHeadCustom_hunter1" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "mystic",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_mystic.detail1",
+				"associatedAspects": [ "drauvenHeadCustom_mystic1" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Aspects",
+		"removeAspects": [ "drauvenHeadCustomization1" ]
+	}
+]
+}

--- a/assets/data/effects/drauven_fix_customization_head2.json
+++ b/assets/data/effects/drauven_fix_customization_head2.json
@@ -1,0 +1,59 @@
+{
+"id": "drauven_fix_customization_head2",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "drauven_fix_customization_head2",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess",
+	"STUB": "Updates Drauven characters to our new system"
+},
+"type": "ABILITIES_CHANGED",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "Test",
+		"value": "warrior",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_warrior.detail2",
+				"associatedAspects": [ "drauvenHeadCustom_warrior2" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "hunter",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_hunter.detail2",
+				"associatedAspects": [ "drauvenHeadCustom_hunter2" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "mystic",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_mystic.detail2",
+				"associatedAspects": [ "drauvenHeadCustom_mystic2" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Aspects",
+		"removeAspects": [ "drauvenHeadCustomization2" ]
+	}
+]
+}

--- a/assets/data/effects/drauven_fix_customization_head3.json
+++ b/assets/data/effects/drauven_fix_customization_head3.json
@@ -1,0 +1,59 @@
+{
+"id": "drauven_fix_customization_head3",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "drauven_fix_customization_head3",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess",
+	"STUB": "Updates Drauven characters to our new system"
+},
+"type": "ABILITIES_CHANGED",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "Test",
+		"value": "warrior",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_warrior.detail3",
+				"associatedAspects": [ "drauvenHeadCustom_warrior3" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "hunter",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_hunter.detail3",
+				"associatedAspects": [ "drauvenHeadCustom_hunter3" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "mystic",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_mystic.detail3",
+				"associatedAspects": [ "drauvenHeadCustom_mystic3" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Aspects",
+		"removeAspects": [ "drauvenHeadCustomization3" ]
+	}
+]
+}

--- a/assets/data/effects/drauven_fix_customization_head4.json
+++ b/assets/data/effects/drauven_fix_customization_head4.json
@@ -1,0 +1,59 @@
+{
+"id": "drauven_fix_customization_head4",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "drauven_fix_customization_head4",
+	"modId": "wildermyth-drauven-pcs-main",
+	"author": "justEthaniguess",
+	"STUB": "Updates Drauven characters to our new system"
+},
+"type": "ABILITIES_CHANGED",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "Test",
+		"value": "warrior",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_warrior.detail4",
+				"associatedAspects": [ "drauvenHeadCustom_warrior4" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "hunter",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_hunter.detail4",
+				"associatedAspects": [ "drauvenHeadCustom_hunter4" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Test",
+		"value": "mystic",
+		"threshold": "1",
+		"onPass": {
+			"class": "AddHistory",
+			"inlineHistory": {
+				"id": "customHeadFix_mystic.detail4",
+				"associatedAspects": [ "drauvenHeadCustom_mystic4" ],
+				"showInSummary": false
+			}
+		}
+	},
+	{
+		"class": "Aspects",
+		"removeAspects": [ "drauvenHeadCustomization4" ]
+	}
+]
+}


### PR DESCRIPTION
Allows old Drauven to be updated to a system which allows head customisation aspects to be shown in legacy.