### PR TITLE
Fixed Ability Targetting

### DIFF
--- a/assets/data/effects/drauven/drauven_pc_cordAndVines.json
+++ b/assets/data/effects/drauven/drauven_pc_cordAndVines.json
@@ -32,9 +32,6 @@
 		"role": "source",
 		"template": "ANY",
 		"type": "SCENERY",
-		"choose": "BY_SCORE",
-		"scoreFunction": "plant+textile",
-		"scoreThreshold": "1",
 		"missionFeedback": {
 			"suggestionScript": "figures.abilitySelectOption",
 			"hoverScript": "figures.abilitySelectHover",
@@ -43,7 +40,8 @@
 			"suggestionFeedback": "FRIENDLY_EFFECT_SUGGESTION",
 			"hoverFeedback": "FRIENDLY_EFFECT_HOVER"
 		},
-		"relationship": "interfusedWithEntity"
+		"relationship": "interfusedWithEntity",
+		"aspectsOneOf": [ "plant", "textile" ]
 	},
 	{
 		"template": "ADJACENT_ENEMY",

--- a/assets/data/effects/drauven/drauven_pc_cordAndVines_oneAction.json
+++ b/assets/data/effects/drauven/drauven_pc_cordAndVines_oneAction.json
@@ -34,9 +34,6 @@
 		"role": "source",
 		"template": "ANY",
 		"type": "SCENERY",
-		"choose": "BY_SCORE",
-		"scoreFunction": "plant+textile",
-		"scoreThreshold": "1",
 		"missionFeedback": {
 			"suggestionScript": "figures.abilitySelectOption",
 			"hoverScript": "figures.abilitySelectHover",
@@ -45,7 +42,8 @@
 			"suggestionFeedback": "FRIENDLY_EFFECT_SUGGESTION",
 			"hoverFeedback": "FRIENDLY_EFFECT_HOVER"
 		},
-		"relationship": "interfusedWithEntity"
+		"relationship": "interfusedWithEntity",
+		"aspectsOneOf": [ "plant", "textile" ]
 	},
 	{
 		"template": "ADJACENT_ENEMY",

--- a/assets/data/effects/drauven/drauven_pc_fissureBell.json
+++ b/assets/data/effects/drauven/drauven_pc_fissureBell.json
@@ -25,9 +25,6 @@
 		"role": "source",
 		"template": "ANY",
 		"type": "SCENERY",
-		"choose": "BY_SCORE",
-		"scoreFunction": "(bone+rock)+statue",
-		"scoreThreshold": "1",
 		"missionFeedback": {
 			"suggestionScript": "figures.abilitySelectOption",
 			"hoverScript": "figures.abilitySelectHover",
@@ -36,7 +33,9 @@
 			"suggestionFeedback": "FRIENDLY_EFFECT_SUGGESTION",
 			"hoverFeedback": "FRIENDLY_EFFECT_HOVER"
 		},
-		"relationship": "interfusedWithEntity"
+		"relationship": "interfusedWithEntity",
+		"aspects": null,
+		"aspectsOneOf": [ "bone", "rock", "statue", "stoneScenery" ]
 	},
 	{
 		"template": "TILE",

--- a/assets/data/effects/drauven/drauven_pc_flamewings.json
+++ b/assets/data/effects/drauven/drauven_pc_flamewings.json
@@ -11,6 +11,7 @@
 "ability": {
 	"icon": "fireleash",
 	"category": "attackAbility",
+	"strictlyBetterThan": [ "mysticRecipeFireleash", "mysticRecipeFlareLamp", "mysticRecipeStealFire" ],
 	"priority": "3",
 	"onlyShowIfPossibleInCharacterSheet": true,
 	"showDescriptionInTooltip": true
@@ -24,9 +25,6 @@
 	{
 		"role": "source",
 		"template": "ANY",
-		"choose": "BY_SCORE",
-		"scoreFunction": "lampIsFireSource+lampCanFlare",
-		"scoreThreshold": "1",
 		"missionFeedback": {
 			"suggestionScript": "figures.abilitySelectOption",
 			"hoverScript": "figures.abilitySelectHover",
@@ -35,7 +33,8 @@
 			"suggestionFeedback": "FRIENDLY_EFFECT_SUGGESTION",
 			"hoverFeedback": "FRIENDLY_EFFECT_HOVER"
 		},
-		"relationship": "interfusedWithEntity"
+		"relationship": "interfusedWithEntity",
+		"aspectsOneOf": [ "lampIsFireSource", "lampCanFlare", "uncontainedFire" ]
 	},
 	{
 		"template": "TILE",
@@ -110,7 +109,7 @@
 			"outcomes": [
 				{
 					"class": "Damage",
-					"amount": "((2*source.lampIsFireSource)+1d2)+((self.SPELL_DAMAGE+self.POTENCY)*0.5)",
+					"amount": "((2*(source.lampIsFireSource+source.uncontainedFire))+1d2)+((self.SPELL_DAMAGE+self.POTENCY)*0.5)",
 					"type": "MAGIC",
 					"useEquippedWeaponForStunt": true,
 					"numDefenders": "COUNT.target"


### PR DESCRIPTION
All basic Drauven interfusion abilities have their targeting fixed so when multiple of the same type of scenery is available one can be selected for the source.