### PR TITLE
Abandoned ban drauven

### DIFF
--- a/assets/data/aspects/drauvenRelationships.json
+++ b/assets/data/aspects/drauvenRelationships.json
@@ -1,23 +1,30 @@
 [
-  {
-    "id": "abandonedDrauven",
-    "lifespan": "all",
-    "importance": -1
-  },
-  {
-    "id": "drauvenHealer",
-    "lifespan": "all"
-  },
-  {
-    "id": "drauvenHealer_sawTiding",
-    "lifespan": "all"
-  },
-  {
-    "id": "drauvenSkeptic",
-    "lifespan": "all"
-  },
-  {
-    "id": "killedAbandonedDrauven",
-    "lifespan": "all"
-  }
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauvenHealer",
+	"importance": -1,
+	"listImportance": -1,
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauvenHealer_sawTiding",
+	"importance": -1,
+	"listImportance": -1,
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauvenSkeptic",
+	"importance": -1,
+	"listImportance": -1,
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "killedAbandonedDrauven",
+	"importance": -1,
+	"listImportance": -1,
+	"lifespan": "all"
+}
 ]

--- a/assets/data/effects/wilderness/theAbandoned.json
+++ b/assets/data/effects/wilderness/theAbandoned.json
@@ -17,7 +17,14 @@
 },
 "targets": [
 	{ "template": "EVENT" },
-	{ "template": "COMPANY", "threatFlavorExists": "drauven" },
+	{
+		"template": "COMPANY",
+		"aspects": null,
+		"aspectValues": [
+			{ "id": "chapterNumber", "maxValue": "4" }
+		],
+		"threatFlavorExists": "drauven"
+	},
 	{ "template": "INJECTED_TILE" },
 	{ "template": "INJECTED_PARTY" },
 	{ "template": "IMMEDIATE_ENEMY" },
@@ -42,6 +49,13 @@
 		"template": "PICK_BY_SCORE",
 		"scoreFunction": "0",
 		"notAlreadyMatchedAs": [ "healer", "hothead" ]
+	},
+	{
+		"role": "subPlot",
+		"template": "PICK_BY_SCORE",
+		"choose": "ALL",
+		"scoreFunction": null,
+		"themes": { "eligibleForTheme": "drauven" }
 	},
 	{
 		"template": "CHOICE",
@@ -3600,7 +3614,7 @@
 						{
 							"class": "AddHistory",
 							"addHistory": [
-								["abandonedDrauven"]
+								[ "abandonedDrauven" ]
 							]
 						}
 					]

--- a/assets/text/effects/tiding/tiding_onAbandonedDrauvenHealed.properties
+++ b/assets/text/effects/tiding/tiding_onAbandonedDrauvenHealed.properties
@@ -1,10 +1,10 @@
 #suppress inspection "UnusedProperty" for whole file
 .longName=Did we do the right thing?
 .name=
-~01~~panel_001~1_narration=<healer.name> sometimes looked out into the night and thought about the drauven child <healer.mf:he/she/they> saved.
+~01~~panel_001~1_narration=<healer.name> sometimes looked out into the night and thought about the Drauven child <healer.mf:he/she/they> saved.
 ~01~~panel_001~2_narration=Did <healer.mf:he/she/they> really do the right thing?
 ~01~~panel_001~2_narration~TWEAK={location:topRight,padXFraction:0.037,padYFraction:0.673,widthFraction:0.572309}
 ~01~~panel_001~3_narration=Or was <hothead.name> right that the child would only grow up to be a monster?
 ~01~~panel_001~3_narration~TWEAK={padXFraction:0.361,padYFraction:0.815,widthFraction:0.61807567}
-~01~~panel_002~1_narration=Similarly, a young drauven sometimes thought about  humans...
+~01~~panel_002~1_narration=Similarly, a young Drauven sometimes thought about humans...
 ~01~~panel_002~nameTag_0=Drauven Child

--- a/assets/text/effects/tiding/tiding_onAbandonedDrauvenHealed_en_GB.properties
+++ b/assets/text/effects/tiding/tiding_onAbandonedDrauvenHealed_en_GB.properties
@@ -1,10 +1,10 @@
 #suppress inspection "UnusedProperty" for whole file
 .longName=Did we do the right thing?
 .name=
-~01~~panel_001~1_narration=<healer.name> sometimes looked out into the night and thought about the drauven child <healer.mf:he/she/they> saved.
+~01~~panel_001~1_narration=<healer.name> sometimes looked out into the night and thought about the Drauven child <healer.mf:he/she/they> saved.
 ~01~~panel_001~2_narration=Did <healer.mf:he/she/they> really do the right thing?
 ~01~~panel_001~2_narration~TWEAK={location:topRight,padXFraction:0.037,padYFraction:0.673,widthFraction:0.572309}
 ~01~~panel_001~3_narration=Or was <hothead.name> right that the child would only grow up to be a monster?
 ~01~~panel_001~3_narration~TWEAK={padXFraction:0.361,padYFraction:0.815,widthFraction:0.61807567}
-~01~~panel_002~1_narration=Similarly, a young drauven sometimes thought about  humans...
+~01~~panel_002~1_narration=Similarly, a young Drauven sometimes thought about humans...
 ~01~~panel_002~nameTag_0=Drauven Child

--- a/assets/text/story/story.properties
+++ b/assets/text/story/story.properties
@@ -1,5 +1,5 @@
 #suppress inspection "UnusedProperty" for whole file
 
-abandonedDrauven.default=<name> was wounded and left to die alone, but was saved by <healer> despite <hothead>'s insistence that they just kill the monster. <name> never forgot <healer>'s kindness... nor <hothead>'s murderous attitude.
-drauvenHealer.default=<name> once discovered a wounded Drauven child and healed it, though <hothead> insisted that they kill the monster instead.
+abandonedDrauven.default=<name> was wounded and left to die alone, but was saved by <healer> despite <hothead>'s insistence that they just leave the monster behind. <name> never forgot <healer>'s kindness... nor <hothead>'s heartless behaviour.
+drauvenHealer.default=<name> once discovered a wounded Drauven child and healed it, though <hothead> insisted that they leave the monster behind instead.
 languageLessons.outcome=<bookish> took time to teach <name> Yandric while they travelled, and before long <self.mf:he was/she was/they were> nearly as comfortable speaking Yandric with <self.mf:his/her/their> human companions as <self.mf:he was/she was/they were> speaking Druvwail.


### PR DESCRIPTION
Stops 'The Abandoned' from triggering if a Drauven is in the company. (NOTE: Please only merge into develop once we have other suitable recruitment events for recruiting Drauven when Drauven already exist in the party.)