### PR TITLE
Bugfix: Prevent name from reverting

### DIFF
--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
@@ -406,7 +406,7 @@
 	"generatedTargets": [
 		{
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "warrior" },
+				"query": { "baseTag": "human", "localizableName": "", "setClass": "warrior" },
 				"addAspects": [
 					{ "id": "drauven_pc_init", "value": "1" }
 				],
@@ -416,7 +416,7 @@
 		{
 			"role": "npc2",
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "hunter" },
+				"query": { "baseTag": "human", "localizableName": "", "setClass": "hunter" },
 				"addAspects": [
 					{ "id": "drauven_pc_init", "value": "1" }
 				],
@@ -426,7 +426,7 @@
 		{
 			"role": "npc3",
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "mystic" },
+				"query": { "baseTag": "human", "localizableName": "", "setClass": "mystic" },
 				"addAspects": [
 					{ "id": "drauven_pc_init", "value": "1" }
 				],


### PR DESCRIPTION
* Adding a localizable name of `""` seems to stop the character from having their name revert on the customize screen for some reason