### PR TITLE
Issue 234: Use new CustomizeHero outcome for new Drauv

### DIFF
--- a/assets/data/effects/drauven_pc_init.json
+++ b/assets/data/effects/drauven_pc_init.json
@@ -24,6 +24,11 @@
 	},
 	{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
 	{
+		"class": "CustomizeHero",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
+	},
+	{
 		"class": "Test",
 		"value": "KNOWS_YANDRIC",
 		"threshold": "1",

--- a/assets/data/effects/job/job_buildDrauvenOutpost.json
+++ b/assets/data/effects/job/job_buildDrauvenOutpost.json
@@ -106,6 +106,12 @@
 			[ "bornDrauven" ]
 		]
 	},
+	{
+		"class": "CustomizeHero",
+		"target": "npc",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
+	},
 	{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "torso" },
 	{
 		"class": "AddHistory",
@@ -114,6 +120,12 @@
 			[ "drauvenBase" ],
 			[ "bornDrauven" ]
 		]
+	},
+	{
+		"class": "CustomizeHero",
+		"target": "npc2",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
 	},
 	{ "class": "ApplyTheme", "target": "npc2", "theme": "drauven", "piece": "torso" },
 	{
@@ -124,6 +136,12 @@
 			[ "bornDrauven" ]
 		]
 	},
+	{
+		"class": "CustomizeHero",
+		"target": "npc3",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
+	},
 	{ "class": "ApplyTheme", "target": "npc3", "theme": "drauven", "piece": "torso" },
 	{
 		"class": "AddHistory",
@@ -133,6 +151,12 @@
 			[ "bornDrauven" ]
 		]
 	},
+	{
+		"class": "CustomizeHero",
+		"target": "npc4",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
+	},
 	{ "class": "ApplyTheme", "target": "npc4", "theme": "drauven", "piece": "torso" },
 	{
 		"class": "AddHistory",
@@ -141,6 +165,12 @@
 			[ "drauvenBase" ],
 			[ "bornDrauven" ]
 		]
+	},
+	{
+		"class": "CustomizeHero",
+		"target": "hero5",
+		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
+		"randomizeColors": [ "skin" ]
 	},
 	{
 		"class": "ApplyTheme",


### PR DESCRIPTION
* Runs the new `CustomizeHero` outcome to select appropriate skin/scale colour and randomize facial features

Closes #234