### PR TITLE
Issue 238: skinColorPaletteOverride

### DIFF
--- a/assets/data/history/drauvenBase.json
+++ b/assets/data/history/drauvenBase.json
@@ -49,9 +49,10 @@
 		"drauvenSkin_naturalRightLeg",
 		"drauvenSkin_naturalHead",
 		"drauvenSkin_naturalTorso",
-		"drauvenSkin_naturalTail"
+		"drauvenSkin_naturalTail",
+		"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 	],
-	"removeAspects":[
+	"removeAspects": [
 		"young",
 		"earlyMiddleAge",
 		"middleAge",

--- a/assets/data/scenario/campaign/fiveChapterDrauvCampaignFamily.json
+++ b/assets/data/scenario/campaign/fiveChapterDrauvCampaignFamily.json
@@ -39,7 +39,8 @@
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
 							"nonhuman",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",
@@ -98,7 +99,8 @@
 							"drauvenGear_clothes",
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",

--- a/assets/data/scenario/campaign/fiveChaptersDrauvCampaignAll.json
+++ b/assets/data/scenario/campaign/fiveChaptersDrauvCampaignAll.json
@@ -37,7 +37,8 @@
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
 							"nonhuman",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",
@@ -97,7 +98,8 @@
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
 							"nonhuman",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",
@@ -158,7 +160,8 @@
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
 							"nonhuman",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",

--- a/assets/data/scenario/campaign/fiveChaptersDrauvCampaignOne.json
+++ b/assets/data/scenario/campaign/fiveChaptersDrauvCampaignOne.json
@@ -37,7 +37,8 @@
 							"humanSkin_suppressClothes",
 							"humanSkin_suppressTorso",
 							"nonhuman",
-							"fluentInYandric"
+							"fluentInYandric",
+							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C"
 						],
 						"removeAspects": [
 							"young",


### PR DESCRIPTION
* Builds a colour palette using eyedropper tool on existing models (artists, please critique!)
* Adds aspect to base Drauven history entry and all campaign PCs

Closes #238