### PR TITLE
Issue 247: Remove init aspect before running other outcomes

### DIFF
--- a/assets/data/effects/drauven_pc_init.json
+++ b/assets/data/effects/drauven_pc_init.json
@@ -13,6 +13,10 @@
 ],
 "outcomes": [
 	{
+		"class": "Aspects",
+		"removeAspects": [ "drauven_pc_init" ]
+	},
+	{
 		"class": "AddHistory",
 		"target": "self",
 		"addHistory": [
@@ -36,10 +40,6 @@
 				[ "fluentInYandric" ]
 			]
 		}
-	},
-	{
-		"class": "Aspects",
-		"removeAspects": [ "drauven_pc_init" ]
 	}
 ]
 }


### PR DESCRIPTION
* Removing the init aspect first in the list of outcomes prevents the initializer from running twice

<img width="167" alt="image" src="https://user-images.githubusercontent.com/86335963/206526474-d7b65df3-a513-4736-89b4-ed4590967139.png">


Closes #247