### PR TITLE
Issue 260: Adds aspect to company if mod is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ This mod attempts to add the ability to recruit Drauven characters to join your 
 
 **This is a work in progress!** The end goal is to produce a full-fledged unlockable race to go out adventuring in the Yondering lands, but each journey begins with a single step! We will do our best to make sure that the `main` branch is always kept in a working state, but expect things to change rapidly right now.
 
-## GETTING STARTED
+## USING THIS MOD IN OTHER MODS
 
-* Clone the repo into a new folder in your Wildermyth user mods. Example: `[Wildermyth Directory]/mods/user/drauven_pcs`
+If you would like to use features of our mod in your own separate mod:
+
+* Check the `company` for the aspect `drauven_pcs_enabled`. 
+* Initialize Drauven characters by adding the aspect `drauven_pc_init` to any characters/NPCs when you create them to turn them into Drauven heroes!
+
+If you have any questions about specific functionality, feel free to either message us through Discord or create a new issue in this repo to request the information you need.
 
 ## CONTRIBUTING
 
@@ -14,6 +19,10 @@ You don't have to be a coder to contribute!
 
 * Ideas are all welcome - if you have any, please add them through the `Issues` tab in this repo!
 * [We have Discord!](https://discord.com/invite/uftGyUa8GS) Drop in to discuss ideas, share art, etc!
+
+### GETTING STARTED
+
+* Clone the repo into a new folder in your Wildermyth user mods. Example: `[Wildermyth Directory]/mods/user/drauven_pcs`
 
 ## NAMING CONVENTIONS
 

--- a/assets/data/aspects/drauven_legacyUnlocks.json
+++ b/assets/data/aspects/drauven_legacyUnlocks.json
@@ -1,15 +1,24 @@
 [
-  {
-    "id": "DrauvenAllies_FirstStepsComplete",
-    "importance": -1
-  },
-  {
-    "id": "DrauvenAllies_Built5Stations",
-    "importance": -1
-  },
-
-  {
-    "id": "legacy_sawLanguageLesson",
-    "importance": -1
-  }
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "DrauvenAllies_Built5Stations",
+	"importance": -1
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "DrauvenAllies_FirstStepsComplete",
+	"effects": [ "drauven_pcs_enabled" ],
+	"importance": -1
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "drauven_pcs_enabled",
+	"importance": -1,
+	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "legacy_sawLanguageLesson",
+	"importance": -1
+}
 ]

--- a/assets/data/effects/misc/drauven_pcs_enabled.json
+++ b/assets/data/effects/misc/drauven_pcs_enabled.json
@@ -1,0 +1,26 @@
+{
+"id": "drauven_pcs_enabled",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "misc/drauven_pcs_enabled",
+	"modId": "wildermyth-drauven-pcs",
+	"author": "Ironskink"
+},
+"type": "LEVEL_START",
+"targets": [
+	{ "template": "ANY_SELF" },
+	{
+		"template": "COMPANY",
+		"aspects": [ "DrauvenAllies_FirstStepsComplete" ]
+	}
+],
+"outcomes": [
+	{
+		"class": "Aspects",
+		"target": "company",
+		"addAspects": [
+			{ "id": "drauven_pcs_enabled", "value": "1", "merge": "max" }
+		]
+	}
+]
+}


### PR DESCRIPTION
* Adds an effect to the `DrauvenAllies_FirstStepsComplete` aspect that adds the additional aspect `drauven_pcs_enabled` at start of campaign
* Allows other mods to test if ours is enabled so that they can create their own Drauven characters to use in the story if they wish.

Closes #260