### PR TITLE
ISSUE-272: Update comic "In Our Wake"

### DIFF
--- a/assets/data/effects/missionOutcome/victory_inOurWake.json
+++ b/assets/data/effects/missionOutcome/victory_inOurWake.json
@@ -3,6 +3,7 @@
 "info": {
 	"dataVersion": 1,
 	"sourceFile": "missionOutcome/victory_inOurWake",
+	"modId": "wildermyth-drauven-pcs",
 	"author": "Anne Austin",
 	"STUB": "Victories occur at the end of missions. No choice is needed in most cases, we can just tell a brief story."
 },
@@ -68,6 +69,14 @@
 		"choose": "BY_SCORE_OPTIONAL",
 		"scoreFunction": "0",
 		"notAlreadyMatchedAs": [ "healer", "friend" ]
+	},
+	{
+		"template": "PICK_BY_SCORE",
+		"type": "HERO",
+		"choose": "BY_SCORE_OPTIONAL",
+		"scoreFunction": "drauven",
+		"scoreThreshold": "1",
+		"aspects": null
 	}
 ],
 "outcomes": [
@@ -693,5 +702,22 @@
 			}
 		]
 	}
-]
+],
+"implications": {
+	"generatedTargets": [
+		{
+			"role": "villain1",
+			"npcId": "drauven_hostile_faction",
+			"createEntity": {
+				"query": {
+					"baseTag": "human",
+					"customHistory": [
+						{ "id": "missionVictory_inOurWake.0", "humanName": "drauvenHostileFaction" }
+					]
+				},
+				"control": "none"
+			}
+		}
+	]
+}
 }

--- a/assets/text/effects/missionOutcome/victory_inOurWake.properties
+++ b/assets/text/effects/missionOutcome/victory_inOurWake.properties
@@ -2,7 +2,7 @@
 .longName=In Our Wake
 .name=
 ~01~~panel_002~1_healer=Someday people will move back to <site>.
-~01~~panel_003~1_healer=<threat.cdgmt:The deep stink of the cult will crawl back into the earth.\n/The memory of Drauven will crumble and rust.\n/The Gorgon slime will run off into the rivers and back to the sea.\n/Broken gears will become tiny treasures to dig up.\n/Thrixl husks will fall apart and their fog will blow far away.>
+~01~~panel_003~1_healer=<threat.cdgmt:The deep stink of the cult will crawl back into the earth.\n/The memory of <volunteer.exists:the <villain1> empire/Drauven> will crumble and rust.\n/The Gorgon slime will run off into the rivers and back to the sea.\n/Broken gears will become tiny treasures to dig up.\n/Thrixl husks will fall apart and their fog will blow far away.>
 ~01~~panel_004~1_healer=Children will find homes for spirits here.
 ~01~~panel_005~1_healer=Young <healer.mf:men/women/people> will build barns alongside their sweethearts.
 ~01~~panel_006~1_healer=Old <healer.mf:men/women/people> will trade in iron and salt.


### PR DESCRIPTION
* Uses the Drauven Hostile Faction name generator to create (or reuse) the name of a Drauven empire if a Drauv is in the party