### PR TITLE
ISSUE-265: Forbid Drauven characters from being the Goofball in "Satisfaction"

### DIFF
--- a/assets/data/effects/missionOutcome/victory_satisfaction.json
+++ b/assets/data/effects/missionOutcome/victory_satisfaction.json
@@ -30,7 +30,8 @@
 		"role": "goofball",
 		"template": "PICK_BY_SCORE",
 		"scoreFunction": "max(GOOFBALL,SNARK)",
-		"scoreThreshold": "80"
+		"scoreThreshold": "80",
+    "aspectValues": [ {"id": "drauven", "forbidden": true} ]
 	},
 	{
 		"role": "bookish",


### PR DESCRIPTION
* Pimples are a somewhat uniquely human thing and not something we would expect reptiles to know about. Easiest to just block Drauven from being eligible for this role.