### PR TITLE
ISSUE-252: Update to "The Abandoned Returns" targeting

### DIFF
--- a/assets/data/aspects/drauvenRelationships.json
+++ b/assets/data/aspects/drauvenRelationships.json
@@ -33,5 +33,11 @@
 	"importance": -1,
 	"listImportance": -1,
 	"lifespan": "all"
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "abandonedDrauvenMaturationYear",
+	"importance": -1,
+	"lifespan": "all"
 }
 ]

--- a/assets/data/effects/theAbandonedReturns.json
+++ b/assets/data/effects/theAbandonedReturns.json
@@ -5,6 +5,7 @@
 	"sourceFile": "theAbandonedReturns",
 	"modId": "wildermyth-drauven-pcs",
 	"author": "Ironskink",
+	"debug": true,
 	"declaredEncounterResults": [ "victory", "defeat", "escape" ]
 },
 "type": "ENCOUNTER_HEROES_ARRIVE_HOSTILE_SITE",
@@ -31,8 +32,11 @@
 		"role": "healer",
 		"template": "PICK_BY_SCORE",
 		"type": "HERO",
-		"scoreFunction": "drauvenHealer_sawTiding",
-		"scoreThreshold": "1",
+		"scoreFunction": "AGE_IN_YEARS",
+		"scoreThreshold": "abandonedDrauvenMaturationYear",
+		"aspectValues": [
+			{ "id": "drauvenHealer" }
+		],
 		"notAlreadyMatchedAs": []
 	},
 	{

--- a/assets/data/effects/wilderness/theAbandoned.json
+++ b/assets/data/effects/wilderness/theAbandoned.json
@@ -1386,6 +1386,13 @@
 						]
 					},
 					{
+						"class": "Aspects",
+						"target": "healer",
+						"addAspects": [
+							{ "id": "abandonedDrauvenMaturationYear", "value": "healer.AGE_IN_YEARS + 8" }
+						]
+					},
+					{
 						"class": "AllowFollowup",
 						"STUB": "Enable tiding during the next interval so that the drauven child can grow up",
 						"id": "encounter_wilderness_theAbandoned.0.playerChose_one.onPass.3"


### PR DESCRIPTION
* Fixes targeting issue in "The Abandoned Returns" so that it can fire even if "Choose Events" is on
* Uses the age of the 'Healer' character as the measuring stick for when the young Drauven is ready for action

Closes #252