### PR TITLE
WIP: ISSUE-269: Name Fixes

### DIFF
--- a/assets/data/effects/arriveAtSite/languageLessons.json
+++ b/assets/data/effects/arriveAtSite/languageLessons.json
@@ -2291,7 +2291,13 @@
 						{ 
 							"id": "languageLessons.1", 
 							"impliedAspects": [ "nameFormulaOverride|drauvenName" ]
-					  }
+					  }, 
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
 					]
 				},
 				"control": "none"

--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
@@ -406,9 +406,20 @@
 	"generatedTargets": [
 		{
 			"createEntity": {
-				"query": { "baseTag": "human", "localizableName": "", "setClass": "warrior" },
+				"query": { 
+					"baseTag": "human", "setClass": "warrior",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}
@@ -416,9 +427,20 @@
 		{
 			"role": "npc2",
 			"createEntity": {
-				"query": { "baseTag": "human", "localizableName": "", "setClass": "hunter" },
+				"query": { 
+					"baseTag": "human", "setClass": "hunter",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					] 
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}
@@ -426,9 +448,20 @@
 		{
 			"role": "npc3",
 			"createEntity": {
-				"query": { "baseTag": "human", "localizableName": "", "setClass": "mystic" },
+				"query": { 
+					"baseTag": "human", "setClass": "mystic",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/hook/hook_Clown_seriousTrouble_intro.json
+++ b/assets/data/effects/hook/hook_Clown_seriousTrouble_intro.json
@@ -646,9 +646,20 @@
 			"npcId": "hookClown_seriousTrouble",
 			"test": "hook2.drauven_pc",
 			"createEntity": {
-				"query": { "baseTag": "human" },
+				"query": {
+					"baseTag": "human",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/hook/hook_Mysterious_fromAnotherTime_arrive.json
+++ b/assets/data/effects/hook/hook_Mysterious_fromAnotherTime_arrive.json
@@ -4716,10 +4716,19 @@
 					"setClass": "mystic",
 					"setAge": "earlyMiddleAge",
 					"setEquipment": "clothes",
-					"looksSimilarTo": "hook"
+					"looksSimilarTo": "hook",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		},
@@ -4749,10 +4758,19 @@
 					"setClass": "warrior",
 					"setAge": "earlyMiddleAge",
 					"setEquipment": "clothes",
-					"looksSimilarTo": "hook"
+					"looksSimilarTo": "hook",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		}

--- a/assets/data/effects/kidRecruit/officialNotification.json
+++ b/assets/data/effects/kidRecruit/officialNotification.json
@@ -31,7 +31,8 @@
 			"class": "Aspects",
 			"target": "hero",
 			"addAspects": [
-				{ "id": "drauven_pc_init", "value": "1" }
+				{ "id": "drauven_pc_init", "value": "1" },
+				{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 			]
 		}
 	},

--- a/assets/data/effects/site/job_drauvenRecruit_branch.json
+++ b/assets/data/effects/site/job_drauvenRecruit_branch.json
@@ -9,7 +9,11 @@
 },
 "type": "BRANCH",
 "verb": "MANEUVER",
-"ability": { "icon": "melee", "priority": "1", "encounterEnabled": true },
+"ability": {
+	"icon": "melee",
+	"priority": "1",
+	"encounterEnabled": true
+},
 "targets": [
 	{ "template": "EVENT" },
 	{
@@ -32,8 +36,8 @@
 		"template": "PICK_BY_SCORE",
 		"type": "HERO",
 		"choose": "BY_SCORE_OPTIONAL",
-		"fromRoles": ["participant"],
 		"scoreFunction": "LEADER",
+		"fromRoles": [ "participant" ],
 		"aspectValues": [
 			{ "id": "nonhuman", "forbidden": true }
 		]
@@ -43,8 +47,8 @@
 		"template": "PICK_BY_SCORE",
 		"type": "HERO",
 		"choose": "BY_SCORE_OPTIONAL",
-		"fromRoles": ["participant"],
 		"scoreFunction": "fluentInDruvwail",
+		"fromRoles": [ "participant" ],
 		"notAlreadyMatchedAs": [ "leader" ]
 	},
 	{
@@ -52,8 +56,8 @@
 		"template": "PICK_BY_SCORE",
 		"type": "HERO",
 		"choose": "BY_SCORE_OPTIONAL",
-		"fromRoles": ["participant"],
 		"scoreFunction": "CHARISMA",
+		"fromRoles": [ "participant" ],
 		"notAlreadyMatchedAs": [ "leader", "friend" ]
 	},
 	{ "role": "foes", "template": "THREAT", "choose": "ONE_RANDOM_TRUE" },
@@ -780,7 +784,7 @@
 					"target": "site",
 					"effectId": "job_drauvenRecruit_training_warrior",
 					"post": "site",
-					"injectedRoles": [ "volunteer", "self", "party" ],
+					"injectedRoles": [ "volunteer", "self" ],
 					"choices": [ "participant" ],
 					"promptSlotsImmediately": true
 				}
@@ -845,7 +849,7 @@
 					"target": "site",
 					"effectId": "job_drauvenRecruit_training_hunter",
 					"post": "site",
-					"injectedRoles": [ "volunteer", "self", "party" ],
+					"injectedRoles": [ "volunteer", "self" ],
 					"choices": [ "participant" ],
 					"promptSlotsImmediately": true
 				}
@@ -944,34 +948,9 @@
 					"target": "site",
 					"effectId": "job_drauvenRecruit_training_mystic",
 					"post": "site",
-					"injectedRoles": [ "volunteer", "self", "party" ],
+					"injectedRoles": [ "volunteer", "self" ],
 					"choices": [ "participant" ],
 					"promptSlotsImmediately": true
-				}
-			]
-		}
-	},
-	{
-		"class": "IfPlayerChose",
-		"target": "party",
-		"ifPlayerChose": "four",
-		"then": {
-			"class": "DoAll",
-			"outcomes": [
-				{
-					"class": "Description",
-					"script": []
-				},
-				{
-					"class": "NewJob",
-					"target": "site",
-					"effectId": "job_drauvenRecruit",
-					"post": "site"
-				},
-				{
-					"class": "Aspects",
-					"target": "volunteer",
-					"removeAspects": [ "npcId|*" ]
 				}
 			]
 		}
@@ -983,7 +962,25 @@
 			"role": "volunteer",
 			"npcId": "DrauvenRecruit",
 			"createEntity": {
-				"query": { "baseTag": "human", "localizableName": "", "setClass": "farmer", "setAge": "young" },
+				"query": {
+					"baseTag": "human",
+					"setClass": "farmer",
+					"setAge": "young",
+					"customHistory": [
+						{
+							"id": "job_drauvenRecruit_branch.0",
+							"impliedAspects": [ "nameFormulaOverride|drauvenName" ],
+							"persistOverLegacy": "never",
+							"showInSummary": false
+						},
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
+				},
 				"addAspects": [
 					{ "id": "drauven_pc_init", "value": "1" }
 				],

--- a/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
+++ b/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
@@ -67,9 +67,20 @@
 	"generatedTargets": [
 		{
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "nonFarmer" },
+				"query": { 
+					"baseTag": "human", "setClass": "nonFarmer",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					] 
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/wildermyth-drauven-pcs_xxx.json
+++ b/assets/data/effects/wildermyth-drauven-pcs_xxx.json
@@ -72,9 +72,21 @@
 	"generatedTargets": [
 		{
 			"createEntity": {
-				"query": { "baseTag": "human", "setClass": "nonFarmer" },
+				"query": {
+					"baseTag": "human",
+					"setClass": "nonFarmer",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
+				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/wilderness/encounter_wilderness_familyBusiness_revision.json
+++ b/assets/data/effects/wilderness/encounter_wilderness_familyBusiness_revision.json
@@ -13398,10 +13398,19 @@
 					"inRelationTo": "hero",
 					"setClass": "farmer",
 					"setAge": "veryOldAge",
-					"looksSimilarTo": "hero"
+					"looksSimilarTo": "hero",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		},
@@ -13449,10 +13458,19 @@
 					"setGender": "oppositeOfRelative",
 					"setClass": "farmer",
 					"setAge": "veryOldAge",
-					"looksSimilarTo": "hero"
+					"looksSimilarTo": "hero",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		},
@@ -13492,10 +13510,19 @@
 					"setGender": "male",
 					"setClass": "farmer",
 					"setAge": "any",
-					"setEquipment": "clothes"
+					"setEquipment": "clothes",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		},
@@ -13523,10 +13550,19 @@
 					"setGender": "female",
 					"setClass": "farmer",
 					"setAge": "any",
-					"setEquipment": "clothes"
+					"setEquipment": "clothes",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		},
@@ -13556,10 +13592,19 @@
 					"setGender": "relativeIsAttracted",
 					"setClass": "farmer",
 					"setAge": "any",
-					"setEquipment": "clothes"
+					"setEquipment": "clothes",
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				]
 			}
 		}

--- a/assets/data/effects/wilderness/theAbandoned.json
+++ b/assets/data/effects/wilderness/theAbandoned.json
@@ -3606,12 +3606,20 @@
 			"createEntity": {
 				"query": {
 					"baseTag": "human",
-					"localizableName": "",
 					"setClass": "nonFarmer",
-					"exactAge": 8
+					"exactAge": 8,
+					"customHistory": [
+						{
+							"id": "wildermyth-drauven-pcs_xxx.0",
+							"persistOverLegacy": "never",
+							"humanName": "drauvenName",
+							"showInSummary": false
+						}
+					]
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" },
+					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
 				],
 				"control": "none",
 				"additionalOutcome": {


### PR DESCRIPTION
* Adds `nameFormulaOverride` as an inline aspect for Drauven
* Removes `localizableName` from Drauven NPCs
* Adds `humanName` inline history back for initial name generation with an end-of-campaign expiry 
 
Seems that there may be an issue with how `nameFormulaOverride` is working on freshly-generated NPCs?  Re-adding the `humanName`/history entry will re-introduce the glitches on the Customize screen, but hopefully by having that history aspect expire at the end of the campaign the inconvenience will be a temporary one.

Closes #269 ... Hopefully