### PR TITLE
Issue 301: Guarantee "The Abandoned" triggering on mod install

### DIFF
--- a/assets/data/effects/wilderness/theAbandoned.json
+++ b/assets/data/effects/wilderness/theAbandoned.json
@@ -12,7 +12,7 @@
 	"icon": "melee",
 	"priority": "1",
 	"cooldown": "oncePerGame",
-	"encounterWeight": "1+(max(0,(1-DrauvenAllies_FirstStepsComplete))*1000)",
+	"encounterWeight": "1+(max(0,(1-company.DrauvenAllies_FirstStepsComplete))*1000)",
 	"encounterEnabled": true
 },
 "targets": [
@@ -30,13 +30,13 @@
 	{
 		"role": "healer",
 		"template": "PICK_BY_SCORE",
-		"scoreFunction": "HEALER",
+		"scoreFunction": "HEALER + (max(0,(1-company.DrauvenAllies_FirstStepsComplete))*60)",
 		"scoreThreshold": "60"
 	},
 	{
 		"role": "hothead",
 		"template": "PICK_BY_SCORE",
-		"scoreFunction": "HOTHEAD+COWARD",
+		"scoreFunction": "HOTHEAD+COWARD + (max(0,(1-company.DrauvenAllies_FirstStepsComplete))*60)",
 		"scoreThreshold": "60",
 		"aspectValues": [
 			{ "id": "drauven", "forbidden": true },
@@ -845,7 +845,7 @@
 		"ifPlayerChose": "one",
 		"then": {
 			"class": "Test",
-			"value": "EVENT_ROLL+roll_one",
+			"value": "EVENT_ROLL+roll_one + (max(0,(1-company.DrauvenAllies_FirstStepsComplete))*50)",
 			"threshold": "difficulty_one",
 			"onPass": {
 				"class": "DoAll",


### PR DESCRIPTION
* Check `DrauvenAllies_FirstStepsComplete` and give bonuses to Healer, Hothead & healer's roll if not set yet
* Fix missing `company.` in `encounterWeight`

Closes #301