### PR TITLE
ISSUE-299 - Skills Project: Human-only warrior skills

### DIFF
--- a/assets/data/aspects/warrior.json
+++ b/assets/data/aspects/warrior.json
@@ -1,0 +1,22 @@
+[
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "warriorDeck_bloodrage",
+	"effects": [ "warriorBloodrageDamageBoost" ],
+	"boostType": "ABILITY_CLASS",
+	"legacyAbilityChoice": true,
+	"abilityForbidAspects": [ "drauven_pc" ],
+	"showInTooltip": true,
+	"info": { "abilityDeckUsage": "warrior", "abilityDeckIcon": "bloodrage" }
+},
+{
+	"modId": "wildermyth-drauven-pcs",
+	"id": "warriorDeck_wolfcall",
+	"effects": [ "warrior_wolfcallTriggerOnKill" ],
+	"boostType": "ABILITY_CLASS",
+	"legacyAbilityChoice": true,
+	"abilityForbidAspects": [ "drauven_pc" ],
+	"showInTooltip": true,
+	"info": { "abilityDeckUsage": "warrior", "abilityDeckIcon": "wolfcall" }
+}
+]


### PR DESCRIPTION
closes #299 
Prevents drauven from being offered wolfcall or bloodrage (preventing broadswipes is handles in #298)