### PR TITLE
ISSUE-541: Updates aging for Omenroad compatibility

### DIFF
--- a/assets/data/aspects/races.json
+++ b/assets/data/aspects/races.json
@@ -24,6 +24,7 @@
 		"friend_teamwork_meleeBlock",
 		"defaultMoveFeedback",
 		"turnEndAchievementChecks",
+		"drauven_agingInit",
 		"drauven_aging",
 		"drauven_pc_cordAndVines",
 		"drauven_pc_flamewings",

--- a/assets/data/effects/aging/drauven_agingInit.json
+++ b/assets/data/effects/aging/drauven_agingInit.json
@@ -1,12 +1,12 @@
 {
   "modId": "wildermyth-drauven-pcs",
-  "id": "drauven_aging",
-  "info": {
+  "id": "drauven_agingInit",
+  "info": { 
     "dataVersion": 1, 
-    "sourceFile": "aging/drauven_aging",
-    "author": "Ironskink"
+    "sourceFile": "aging/drauven_agingInit",
+    "author": "Ironskink" 
   },
-  "type": "MONTHLY",
+  "type": "ABILITIES_CHANGED",
   "targets": [
     {
       "template": "SELF",
@@ -18,6 +18,12 @@
     }
   ],
   "outcomes": [
+    {
+      "class": "Test",
+      "value": "IS_DUNGEONMODE",
+      "threshold": 1,
+      "onPass": { "class": "ModifyStats", "stat": "AGE", "value": "max(0, 50-self.AGE)" }
+    },
     {
       "class": "BranchAbility",
       "branchAbility": "drauven_setAgingStats",

--- a/assets/data/effects/aging/drauven_setAgingStats.json
+++ b/assets/data/effects/aging/drauven_setAgingStats.json
@@ -1,0 +1,86 @@
+{
+  "modId": "wildermyth-drauven-pcs",
+  "id": "drauven_setAgingStats",
+  "info": { 
+    "dataVersion": 1, 
+    "sourceFile": "aging/drauven_setAgingStats",
+    "author": "Ironskink" 
+  },
+  "type": "BRANCH",
+  "targets": [
+    {
+      "template": "SELF"
+    }
+  ],
+  "outcomes": [
+    {
+      "class": "Aspects",
+      "addAspects": [
+        {
+          "id": "drauven_aging_armour",
+          "value": "max(self.AGE_IN_YEARS-20,0)/30 + 1.0",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_warding",
+          "value": "max(self.AGE_IN_YEARS-25,0)/30",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_speed",
+          "value": "min(max(30-self.AGE_IN_YEARS, 0), 20)/20*1.4 + min(max(self.AGE_IN_YEARS-35, 0),45)/45 * -1.8 + min(max(self.AGE_IN_YEARS-80,0), 40)/40*-1.2",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_speed_penalty",
+          "value": "-1*(min(max(30-self.AGE_IN_YEARS, 0), 20)/20*1.4 + min(max(self.AGE_IN_YEARS-35, 0),45)/45 * -1.8 + min(max(self.AGE_IN_YEARS-80,0), 40)/40*-1.2)",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_charisma",
+          "value": "min(max(self.AGE_IN_YEARS-20, 0),20)*0.5 - min(max(self.AGE_IN_YEARS-50, 0), 40)*0.5",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_charisma_penalty",
+          "value": "-1*(min(max(self.AGE_IN_YEARS-20, 0),20)*0.5 - min(max(self.AGE_IN_YEARS-50, 0), 40)*0.5)",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_tenacity",
+          "value": "min(max(self.AGE_IN_YEARS-40, 0),40)*0.7",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_dodge_penalty",
+          "value": "-1*(min(max(self.AGE_IN_YEARS-25, 0),55)/55 * -15 + min(max(self.AGE_IN_YEARS-80,0), 40)/40*-20)",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_health",
+          "value": "min(max(self.AGE_IN_YEARS-25, 0), 35)/35 * 5 + max(self.AGE_IN_YEARS-60,0)/60*3",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_perception_penalty",
+          "value": "-1*(min(max(self.AGE_IN_YEARS-60, 0),60)/60*-4)",
+          "merge": "replace"
+        },
+        {
+          "id": "drauven_aging_recovery",
+          "value": "min(self.AGE_IN_YEARS, 50)*0.5 - max(self.AGE_IN_YEARS-80,0)*0.5",
+          "merge": "replace"
+        }
+      ],
+      "removeAspects": [
+        "young",
+        "earlyMiddleAge",
+        "middleAge",
+        "lateMiddleAge",
+        "oldAge",
+        "veryOldAge",
+        "extremeOldAge"
+      ]
+    }
+  ]
+  }


### PR DESCRIPTION
* If character is playing in Omenroad, sets age to 50
* Updates our Aging effects to run as a `Branch`
* Aging check triggers `Monthly` during a compaign plus during the `init` check

Closes #541