### PR TITLE
ISSUE-611: Adds `weightExp`to recruit event randomizer

### DIFF
--- a/assets/data/effects/aging/drauven_aging.json
+++ b/assets/data/effects/aging/drauven_aging.json
@@ -1,7 +1,7 @@
 {
-  "modId": "wildermyth-drauven-pcs",
   "id": "drauven_aging",
   "info": {
+    "modId": "wildermyth-drauven-pcs",
     "dataVersion": 1, 
     "sourceFile": "aging/drauven_aging",
     "author": "Ironskink"

--- a/assets/data/effects/aging/drauven_agingInit.json
+++ b/assets/data/effects/aging/drauven_agingInit.json
@@ -1,7 +1,7 @@
 {
-  "modId": "wildermyth-drauven-pcs",
   "id": "drauven_agingInit",
   "info": { 
+    "modId": "wildermyth-drauven-pcs",
     "dataVersion": 1, 
     "sourceFile": "aging/drauven_agingInit",
     "author": "Ironskink" 

--- a/assets/data/effects/aging/drauven_setAgingStats.json
+++ b/assets/data/effects/aging/drauven_setAgingStats.json
@@ -1,7 +1,7 @@
 {
-  "modId": "wildermyth-drauven-pcs",
   "id": "drauven_setAgingStats",
   "info": { 
+    "modId": "wildermyth-drauven-pcs",
     "dataVersion": 1, 
     "sourceFile": "aging/drauven_setAgingStats",
     "author": "Ironskink" 

--- a/assets/data/effects/site/job_drauvenRecruit.json
+++ b/assets/data/effects/site/job_drauvenRecruit.json
@@ -42,6 +42,27 @@
 		"test": "GREATER_THAN_OR_EQUAL_TO",
 		"a": "RESOURCE.legacyPoints",
 		"b": "3"
+	},
+	{
+		"role": "hero2",
+		"template": "HERO_BY_SCORE",
+		"choose": "ANY",
+		"scoreFunction": null,
+		"fromRoles": [ "participant" ],
+		"aspects": [ "drauven" ],
+		"notAlreadyMatchedAs": []
+	},
+	{
+		"role": "hero3",
+		"template": "HERO_BY_SCORE",
+		"choose": "ANY",
+		"scoreFunction": null,
+		"fromRoles": [ "participant" ],
+		"aspects": null,
+		"aspectValues": [
+			{ "id": "nonhuman", "forbidden": true }
+		],
+		"notAlreadyMatchedAs": []
 	}
 ],
 "outcomes": [
@@ -57,9 +78,11 @@
 				"outcome": { "class": "Branch", "branchEvent": "job_drauvenRecruit_branch" }
 			},
 			{
+				"weightExp": "greaterThan(COUNT.participant,1)",
 				"outcome": { "class": "Branch", "branchEvent": "job_inspiredDrauvenHero_branch" }
 			},
 			{
+				"weightExp": "greaterThan(COUNT.participant,2)",
 				"outcome": { "class": "Branch", "branchEvent": "job_drauvenRecruit_trainingBranch" }
 			}
 		]

--- a/assets/data/effects/site/job_drauvenRecruit.json
+++ b/assets/data/effects/site/job_drauvenRecruit.json
@@ -49,7 +49,7 @@
 		"choose": "ANY",
 		"scoreFunction": null,
 		"fromRoles": [ "participant" ],
-		"aspects": [ "drauven" ],
+		"aspects": [ "alive", "drauven" ],
 		"notAlreadyMatchedAs": []
 	},
 	{
@@ -58,7 +58,6 @@
 		"choose": "ANY",
 		"scoreFunction": null,
 		"fromRoles": [ "participant" ],
-		"aspects": null,
 		"aspectValues": [
 			{ "id": "nonhuman", "forbidden": true }
 		],
@@ -78,7 +77,6 @@
 				"outcome": { "class": "Branch", "branchEvent": "job_drauvenRecruit_branch" }
 			},
 			{
-				"weightExp": "greaterThan(COUNT.participant,1)",
 				"outcome": { "class": "Branch", "branchEvent": "job_inspiredDrauvenHero_branch" }
 			},
 			{


### PR DESCRIPTION
* Prevents randomly selecting recruit comics when we don't have enough heroes to fill the required roles
* Linting: Fixes position of some `modId` lines

Closes #611