### PR TITLE
ISSUE-638: Use the `humanName` field rather than `nameFormulaOverride`

### DIFF
--- a/assets/data/effects/arriveAtSite/languageLessons.json
+++ b/assets/data/effects/arriveAtSite/languageLessons.json
@@ -2289,8 +2289,7 @@
 					"baseTag": "human",
 					"customHistory": [
 						{ 
-							"id": "languageLessons.1", 
-							"impliedAspects": [ "nameFormulaOverride|drauvenName" ]
+							"id": "languageLessons.1"
 					  }, 
 						{
 							"id": "wildermyth-drauven-pcs_xxx.0",

--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_devtestEasyDrauvRecruit.json
@@ -410,8 +410,7 @@
 					"baseTag": "human", "setClass": "warrior"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}
@@ -423,8 +422,7 @@
 					"baseTag": "human", "setClass": "hunter"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}
@@ -436,8 +434,7 @@
 					"baseTag": "human", "setClass": "mystic"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/drauven_pc_init.json
+++ b/assets/data/effects/drauven_pc_init.json
@@ -20,8 +20,7 @@
 		"class": "AddHistory",
 		"target": "self",
 		"addHistory": [
-			[ "drauvenBase" ],
-			[ "drauvenNPCName" ]
+			[ "drauvenBase" ]
 		]
 	},
 	{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },

--- a/assets/data/effects/hook/hook_Clown_seriousTrouble_intro.json
+++ b/assets/data/effects/hook/hook_Clown_seriousTrouble_intro.json
@@ -650,8 +650,7 @@
 					"baseTag": "human"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/makeHeroDrauven.json
+++ b/assets/data/effects/makeHeroDrauven.json
@@ -21,8 +21,7 @@
 		"class": "AddHistory",
 		"target": "hero",
 		"addHistory": [
-			[ "drauvenBase" ],
-			[ "drauvenNPCName" ]
+			[ "drauvenBase" ]
 		]
 	},
 	{ "class": "ApplyTheme", "target": "hero", "theme": "drauven", "piece": "torso" },

--- a/assets/data/effects/site/branch_convertFarmersToDrauven.json
+++ b/assets/data/effects/site/branch_convertFarmersToDrauven.json
@@ -62,8 +62,7 @@
 						"class": "AddHistory",
 						"target": "focus",
 						"addHistory": [
-							[ "drauvenBase" ],
-							[ "drauvenNPCName" ]
+							[ "drauvenBase" ]
 						]
 					},
 					{

--- a/assets/data/effects/site/site_hasDrauvenFarmers.json
+++ b/assets/data/effects/site/site_hasDrauvenFarmers.json
@@ -63,8 +63,7 @@
 						"class": "AddHistory",
 						"target": "focus",
 						"addHistory": [
-							[ "drauvenBase" ],
-							[ "drauvenNPCName" ]
+							[ "drauvenBase" ]
 						]
 					},
 					{

--- a/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
+++ b/assets/data/effects/wildermyth-drauven-pcs-main_heyItsaNewDrauv.json
@@ -71,8 +71,7 @@
 					"baseTag": "human", "setClass": "nonFarmer"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/effects/wildermyth-drauven-pcs_xxx.json
+++ b/assets/data/effects/wildermyth-drauven-pcs_xxx.json
@@ -77,8 +77,7 @@
 					"setClass": "nonFarmer"
 				},
 				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
+					{ "id": "drauven_pc_init", "value": "1" }
 				],
 				"control": "none"
 			}

--- a/assets/data/history/drauvenBase.json
+++ b/assets/data/history/drauvenBase.json
@@ -57,8 +57,7 @@
 		"drauvenSkin_naturalTorso",
 		"drauvenSkin_naturalTail",
 		"drauvenGear_clothes",
-		
-		"nameFormulaOverride|drauvenName",
+
 		"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C",
 		"rigOverride|Drauven"
 	],
@@ -74,6 +73,7 @@
 		"humanSkin_naturalRightHand",
 		"humanSkin_naturalHead"
 	],
+	"humanName": "drauvenName",
 	"showInSummary": false
 }
 ]

--- a/assets/data/scenario/campaign/fiveChapterDrauvCampaignFamily.json
+++ b/assets/data/scenario/campaign/fiveChapterDrauvCampaignFamily.json
@@ -40,7 +40,6 @@
 							"nonhuman",
 							"fluentInYandric",
 
-							"nameFormulaOverride|drauvenName",
 							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C",
 							"rigOverride|Drauven"
 						],
@@ -56,6 +55,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{
@@ -113,6 +113,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{

--- a/assets/data/scenario/campaign/fiveChaptersDrauvCampaignAll.json
+++ b/assets/data/scenario/campaign/fiveChaptersDrauvCampaignAll.json
@@ -38,7 +38,6 @@
 							"nonhuman",
 							"fluentInYandric",
 							
-							"nameFormulaOverride|drauvenName",
 							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C",
 							"rigOverride|Drauven"
 						],
@@ -54,6 +53,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{
@@ -96,7 +96,6 @@
 							"nonhuman",
 							"fluentInYandric",
 							
-							"nameFormulaOverride|drauvenName",
 							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C",
 							"rigOverride|Drauven"
 						],
@@ -112,6 +111,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{
@@ -154,7 +154,6 @@
 							"nonhuman",
 							"fluentInYandric",
 							
-							"nameFormulaOverride|drauvenName",
 							"skinColorPaletteOverride|84771B|A19015|606B5C|88927E|544813|7E7426|757546|757546|8B7553|C5BF8C",
 							"rigOverride|Drauven"
 						],
@@ -170,6 +169,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{

--- a/assets/data/scenario/campaign/fiveChaptersDrauvCampaignOne.json
+++ b/assets/data/scenario/campaign/fiveChaptersDrauvCampaignOne.json
@@ -54,6 +54,7 @@
 							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						],
+						"humanName": "drauvenName",
 						"showInSummary": false
 					},
 					{


### PR DESCRIPTION
* Now that the `humanName` bugs have been fixed, we can safely rely on it to correctly generate Drauven names without also needing the `nameFormulaOverride` stopgap

Closes #638