### PR TITLE
BUGFIX: Torso migration caused weapon drops

### DIFF
--- a/assets/data/effects/arriveAtSite/drauvRecruit.json
+++ b/assets/data/effects/arriveAtSite/drauvRecruit.json
@@ -1508,7 +1508,7 @@
 				"additionalOutcome": {
 					"class": "DoAll",
 					"outcomes": [
-						{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"target": "npc",

--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_dEVTESTDefendDrauvfromGorgons.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_dEVTESTDefendDrauvfromGorgons.json
@@ -115,7 +115,7 @@
 								[ "drauvenCustomizationBody" ]
 							]
 						},
-						{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "target": "npc", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"target": "npc",
@@ -143,7 +143,7 @@
 								[ "drauvenCustomizationBody" ]
 							]
 						},
-						{ "class": "ApplyTheme", "target": "npc2", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "target": "npc2", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"target": "npc",

--- a/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_joinDrauvAgainstFoes.json
+++ b/assets/data/effects/arriveAtSite/wildermyth-drauven-pcs_joinDrauvAgainstFoes.json
@@ -122,7 +122,7 @@
 								[ "drauvenCustomizationBody" ]
 							]
 						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers" ],
@@ -147,7 +147,7 @@
 								[ "drauvenCustomizationBody" ]
 							]
 						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"target": "npc",
@@ -173,7 +173,7 @@
 								[ "drauvenCustomizationBody" ]
 							]
 						},
-						{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
+						{ "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
 						{
 							"class": "CustomizeHero",
 							"target": "npc",

--- a/assets/data/effects/drauven_pc_init.json
+++ b/assets/data/effects/drauven_pc_init.json
@@ -24,7 +24,7 @@
 			[ "drauvenNPCName" ]
 		]
 	},
-	{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" },
+	{ "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
 	{
 		"class": "CustomizeHero",
 		"randomizeSlots": [ "zzz_drauven01_Head", "zzz_drauven02_Feathers", "zzz_drauven03_Horns", "zzz_drauven04_Whiskers", "zzz_drauven05_Helmet", "zzz_drauven06_Armour" ],

--- a/assets/data/effects/drauven_theme_init.json
+++ b/assets/data/effects/drauven_theme_init.json
@@ -22,6 +22,6 @@
 			"removeAspects": [ "drauven_theme_init" ]
 		}
 	},
-	{ "class": "ApplyTheme", "theme": "drauven", "piece": "torso" }
+	{ "class": "ApplyTheme", "theme": "drauven", "piece": "species" }
 ]
 }

--- a/assets/data/effects/makeHeroDrauven.json
+++ b/assets/data/effects/makeHeroDrauven.json
@@ -25,7 +25,7 @@
 			[ "drauvenNPCName" ]
 		]
 	},
-	{ "class": "ApplyTheme", "target": "hero", "theme": "drauven", "piece": "torso" },
+	{ "class": "ApplyTheme", "target": "hero", "theme": "drauven", "piece": "species" },
 	{
 		"class": "CustomizeHero",
 		"target": "hero",

--- a/assets/data/effects/migrations/Issue-631_Torso_migration.json
+++ b/assets/data/effects/migrations/Issue-631_Torso_migration.json
@@ -7,7 +7,7 @@
     "author": "Ironskink",
     "STUB": "Updates characters to use the updated 'species' piece instead of the 'torso' slot, allowing characters to get torso transformations"
   },
-  "type": "ABILITIES_CHANGED",
+  "type": "DAILY",
   "targets": [
     {
       "template": "SELF",
@@ -17,8 +17,8 @@
     }
   ],
   "outcomes": [
-    { "class": "RemoveTheme", "specificTheme": "drauven", "specificPiece": "torso" },
-    { "class": "ApplyTheme", "theme": "drauven", "piece": "species" }
+    { "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
+    { "class": "RemoveTheme", "specificTheme": "drauven", "specificPiece": "torso" }
   ]
 
   

--- a/assets/data/effects/migrations/v0-14_updateRig.json
+++ b/assets/data/effects/migrations/v0-14_updateRig.json
@@ -33,7 +33,7 @@
 					"specificTheme": "drauven",
 					"specificPiece": "torso"
 				},
-				{ "class": "ApplyTheme", "target": "self", "theme": "drauven", "piece": "torso" }
+				{ "class": "ApplyTheme", "target": "self", "theme": "drauven", "piece": "species" }
 			]
 		}
 	},
@@ -53,8 +53,6 @@
 						"id": "removeHumanSkinAspects",
 						"showInSummary": false,
 						"removeAspects": [
-							"humanSkin_naturalLeftHand",
-							"humanSkin_naturalRightHand",
 							"humanSkin_naturalHead"
 						]
 					}

--- a/assets/data/effects/site/branch_convertFarmersToDrauven.json
+++ b/assets/data/effects/site/branch_convertFarmersToDrauven.json
@@ -70,7 +70,7 @@
 						"class": "ApplyTheme",
 						"target": "focus",
 						"theme": "drauven",
-						"piece": "torso"
+						"piece": "species"
 					},
 					{
 						"class": "CustomizeHero",

--- a/assets/data/effects/site/site_hasDrauvenFarmers.json
+++ b/assets/data/effects/site/site_hasDrauvenFarmers.json
@@ -71,7 +71,7 @@
 						"class": "ApplyTheme",
 						"target": "focus",
 						"theme": "drauven",
-						"piece": "torso"
+						"piece": "species"
 					},
 					{
 						"class": "CustomizeHero",

--- a/assets/data/themes/drauven.json
+++ b/assets/data/themes/drauven.json
@@ -65,7 +65,8 @@
 		],
 		"canBeAwardedRandomly": false,
 		"applyAutomaticallyIfHave": [
-			[ "torso" ]
+			[ "torso" ],
+			[ "species" ]
 		]
 	},
 	{


### PR DESCRIPTION
* Fix for the torso migration causing heroes recruited from legacy to recruit without any weapons
* Updates missed places where we were applying the `torso` piece to instead use the new `species` one
Closes #631 (Again)