### PR TITLE
ISSUE-644: Drauven able to wear armour

### DIFF
--- a/assets/data/effects/migrations/Issue-631_Torso_migration.json
+++ b/assets/data/effects/migrations/Issue-631_Torso_migration.json
@@ -17,8 +17,8 @@
     }
   ],
   "outcomes": [
-    { "class": "ApplyTheme", "theme": "drauven", "piece": "species" },
-    { "class": "RemoveTheme", "specificTheme": "drauven", "specificPiece": "torso" }
+    { "class": "RemoveTheme", "specificTheme": "drauven", "specificPiece": "torso" },
+    { "class": "ApplyTheme", "theme": "drauven", "piece": "species" }
   ]
 
   

--- a/assets/data/peopleParts/drauvenArmour00.json
+++ b/assets/data/peopleParts/drauvenArmour00.json
@@ -15,7 +15,7 @@
         "name": "armor_Upper_Primary",
         "tint": "primary",
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3565
       },
       {
@@ -23,7 +23,7 @@
         "tint": "primary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3566
       },
       {
@@ -31,13 +31,13 @@
         "tint": "primary",
         "tintAmount": 0.3,
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3567
       },
       {
         "name": "armor_Upper_Untinted",
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3568        
       },
 
@@ -46,7 +46,7 @@
         "name": "armor_Upper_Tuck_Primary",
         "tint": "primary",
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1455
       },
       {
@@ -54,7 +54,7 @@
         "tint": "primary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1456
       },
       {
@@ -62,13 +62,13 @@
         "tint": "primary",
         "tintAmount": 0.3,
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1457
       },
       {
         "name": "armor_Upper_Tuck_Untinted",
         "ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1458        
       },
 
@@ -78,7 +78,7 @@
         "tint": "primary",
         "tintAmount": 0.1,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 5
       },
       {
@@ -86,7 +86,7 @@
         "tint": "primary",
         "tintAmount": 0.2,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3564
       },
       {
@@ -94,14 +94,14 @@
         "tint": "primary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3565
       },
       {
         "name": "OutfitVariation_Cape_Front_Detail_Secondary",
         "tint": "secondary",
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3566
       },
       {
@@ -109,14 +109,14 @@
         "tint": "secondary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3567
       },
       {
         "name": "OutfitVariation_Cape_Front_Detail_Primary",
         "tint": "primary",
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3568
       },
       {
@@ -124,14 +124,14 @@
         "tint": "primary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 3569
       },
       {
         "name": "armor_base_Detail_Secondary",
         "tint": "secondary",
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1352
       },
       {
@@ -139,20 +139,20 @@
         "tint": "secondary",
         "tintAmount": 0.5,
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1353
       },
       {
         "name": "armor_base_Detail_Primary",
         "tint": "primary",
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
         "depth": 1355
       },
       {
         "name": "deeven_talisman",
         "ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
+        "ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
         "depth": 2950
       }
 

--- a/assets/data/peopleParts/drauvenArmour_deeven01.json
+++ b/assets/data/peopleParts/drauvenArmour_deeven01.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "mystic", "rigOverride|Drauven"],
+	"requireAspects": ["theme_drauven", "mystic", "rigOverride|Drauven"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -13,13 +13,13 @@
 		{
 			"name": "OutfitVariation_CapeFixedColour_Behind",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 5
 		},
 		{
 			"name": "OutfitVariation_CapeFixedColour_Front",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3565
 		},
 		{
@@ -35,14 +35,14 @@
 		{
 			"name": "deeven_talisman",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
 			"depth": 2950
 		},
 		{
 			"name": "armor_base_Detail_Primary",
 			"tint": "primary", "tintAmount": 0.80,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1355
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_deeven02.json
+++ b/assets/data/peopleParts/drauvenArmour_deeven02.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "mystic"],
+	"requireAspects": ["theme_drauven", "mystic"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -15,14 +15,14 @@
 			"tint": "primary",
 			"tintAmount": 0.2,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 5
 		},
 		{
 			"name": "OutfitVariation_Feathercloak_Back_Secondary",
 			"tint": "secondary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 6
 		},
 		{
@@ -30,13 +30,13 @@
 			"tint": "primary",
 			"tintAmount": 0.2,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 7
 		},
 		{
 			"name": "OutfitVariation_Feathercloak_Back_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 8
 		},
 		{
@@ -44,14 +44,14 @@
 			"tint": "primary",
 			"tintAmount": 0.8,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3565
 		},
 		{
 			"name": "OutfitVariation_Feathercloak_Front_Secondary",
 			"tint": "secondary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3566
 		},
 		{
@@ -59,26 +59,26 @@
 			"tint": "primary",
 			"tintAmount": 0.7,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3567
 		},
 		{
 			"name": "OutfitVariation_Feathercloak_Front_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3568
 		},
 		{
 			"name": "deeven_talisman",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes", "slotFilled_AUGMENT_BELT", "slotFilled_AUGMENT_SASH", "slotFilled_AUGMENT_TALISMAN"],
 			"depth": 2950
 		},
 		{
 			"name": "armor_base_Detail_Primary",
 			"tint": "primary", "tintAmount": 0.80,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1355
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_deeven03.json
+++ b/assets/data/peopleParts/drauvenArmour_deeven03.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "mystic"],
+	"requireAspects": ["theme_drauven", "mystic"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -14,7 +14,7 @@
 			"name": "armor_base_Detail_Secondary",
 			"tint": "secondary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1352
 		},
 		{
@@ -22,14 +22,14 @@
 			"tint": "secondary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1353
 		},
 		{
 			"name": "armor_base_Detail_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "mystic"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1355
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_haunt01.json
+++ b/assets/data/peopleParts/drauvenArmour_haunt01.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "hunter"],
+	"requireAspects": ["theme_drauven", "hunter"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -23,7 +23,7 @@
 		{
 			"name": "OutfitVariation_Feathersteel_Straps_Untinted",
 			"depth": 1340,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "slotFilled_AUGMENT_STRAP"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes", "slotFilled_AUGMENT_STRAP"]
 		},
 
 		{

--- a/assets/data/peopleParts/drauvenArmour_haunt02.json
+++ b/assets/data/peopleParts/drauvenArmour_haunt02.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "hunter"],
+	"requireAspects": ["theme_drauven", "hunter"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -14,13 +14,13 @@
 			"name": "OutfitVariation_Shouldersash_Back_Secondary",
 			"tint": "secondary",
 			"depth": 500,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Back_Texture_Secondary",
 			"tint": "secondary",
 			"depth": 501,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Back_Untinted",
@@ -30,24 +30,24 @@
 			"name": "OutfitVariation_Shouldersash_Front_Secondary",
 			"tint": "secondary",
 			"depth": 1340,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Front_Texture_Secondary",
 			"tint": "secondary",
 			"depth": 1341,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Front_Highlight_Secondary",
 			"tint": "secondary",
 			"depth": 1342,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Front_Untinted",
 			"depth": 1343,
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"]
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"]
 		},
 		{
 			"name": "OutfitVariation_Shouldersash_Strap_Untinted",
@@ -72,7 +72,8 @@
 			"name": "outfitVariation2_armR_2hand",
 			"tint": "secondary", "tintAmount": 0.6,
 			"depth": 8001,
-			"ifNoOwnerAspects": ["farmer", "drauvenSkin_suppressClothes", "themeSlotFilled_rightArm", "slotFilled_AUGMENT_BRACELET"]
+			"ifNoOwnerAspects": ["farmer", "drauvenSkin_suppressClothes", "themeSlotFilled_rightArm", "slotFilled_AUGMENT_BRACELET"],
+			"rigMode": "twoHanded"
 		}
 	]
 }

--- a/assets/data/peopleParts/drauvenArmour_stump01.json
+++ b/assets/data/peopleParts/drauvenArmour_stump01.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "warrior"],
+	"requireAspects": ["theme_drauven", "warrior"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -20,7 +20,7 @@
 			"name": "armor_Upper_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3005
 		},
 		{
@@ -28,7 +28,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3006
 		},
 		{
@@ -36,13 +36,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3007
 		},
 		{
 			"name": "armor_Upper_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3008        
 		},
 
@@ -51,7 +51,7 @@
 			"name": "armor_Upper_Tuck_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1455
 		},
 		{
@@ -59,7 +59,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1456
 		},
 		{
@@ -67,13 +67,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1457
 		},
 		{
 			"name": "armor_Upper_Tuck_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1458        
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_stump02.json
+++ b/assets/data/peopleParts/drauvenArmour_stump02.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "warrior"],
+	"requireAspects": ["theme_drauven", "warrior"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -21,7 +21,7 @@
 			"name": "armor_Upper_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3005
 		},
 		{
@@ -29,7 +29,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3006
 		},
 		{
@@ -37,13 +37,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3007
 		},
 		{
 			"name": "armor_Upper_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3008        
 		},
 
@@ -52,7 +52,7 @@
 			"name": "armor_Upper_Tuck_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1455
 		},
 		{
@@ -60,7 +60,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1456
 		},
 		{
@@ -68,13 +68,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1457
 		},
 		{
 			"name": "armor_Upper_Tuck_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1458        
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_stump03.json
+++ b/assets/data/peopleParts/drauvenArmour_stump03.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "warrior"],
+	"requireAspects": ["theme_drauven", "warrior"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},
@@ -21,7 +21,7 @@
 			"name": "armor_Upper_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3005
 		},
 		{
@@ -29,7 +29,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3006
 		},
 		{
@@ -37,13 +37,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3007
 		},
 		{
 			"name": "armor_Upper_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 3008        
 		},
 
@@ -52,7 +52,7 @@
 			"name": "armor_Upper_Tuck_Primary",
 			"tint": "primary",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1455
 		},
 		{
@@ -60,7 +60,7 @@
 			"tint": "primary",
 			"tintAmount": 0.5,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1456
 		},
 		{
@@ -68,13 +68,13 @@
 			"tint": "primary",
 			"tintAmount": 0.3,
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1457
 		},
 		{
 			"name": "armor_Upper_Tuck_Untinted",
 			"ifOwnerAspects": ["rigOverride|Drauven", "warrior"],
-			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes"],
+			"ifNoOwnerAspects": ["drauvenSkin_suppressClothes", "humanSkin_suppressClothes"],
 			"depth": 1458        
 		}
 	]

--- a/assets/data/peopleParts/drauvenArmour_stump04.json
+++ b/assets/data/peopleParts/drauvenArmour_stump04.json
@@ -1,7 +1,7 @@
 {
 	"type": "extra",
 	"extraSlot": "zzz_drauven06_Armour",
-	"requireAspects": ["themePiece_drauven_torso", "warrior"],
+	"requireAspects": ["theme_drauven", "warrior"],
 
 	"groups": [
 		{"groupIndex": 0, "male": true, "maleWeight": 1, "female": true, "femaleWeight": 1},


### PR DESCRIPTION
* Migration order seems to have been removing the `ATTACHMENTS_suppressArmor` aspect by having a theme piece removed that included that aspect after adding the theme piece with the aspect
* Changes order of theme update to prevent unintended side effect
* Updates armour customization `peopleParts` so that armour customization can happen without the specific `torso` piece
* Updates `peopleParts` so that the clothes can be diabled in comics

Closes #644 