### PR TITLE
ISSUE-670: Update kidRecruit modInjection

### DIFF
--- a/assets/data/modInjections/effects/kidRecruit/officialNotification.json
+++ b/assets/data/modInjections/effects/kidRecruit/officialNotification.json
@@ -9,19 +9,12 @@
 			"value": "sponsor.drauven",
 			"threshold": "1",
 			"onPass": {
-				"class": "Aspects",
+				"class": "BranchAbility",
 				"target": "hero",
-				"addAspects": [
-					{ "id": "drauven_pc_init", "value": "1" },
-					{ "id": "nameFormulaOverride|drauvenName", "value": "1" }
-				]
+				"targetRole": "hero",
+				"branchAbility": "makeHeroDrauven|1"
 			}
 		}
-	},
-	{
-		"jsonPath": "outcomes/[1]/then/outcomes/[2]/becomeAllyOf",
-		"type": "enumeration",
-		"enumeration": { "class": "abilityTargetRole", "value": "company" }
 	}
 ]
 }


### PR DESCRIPTION
* Updates the `modInjection` for the kidRecruit event to give hero a proper Drauven name that registers before the comic happens