### PR TITLE
Deployment updates and security fixes

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,15 @@
+# # # Use rsync EXCLUDE syntax # # #
+
+######################
+# Development Assets #
+######################
+# Photoshop Development Assets
+*.psd
+
+##########
+# GITHUB #
+##########
+# Discord Bot Avatar
+discordBotAvatar.png
+# Github Bot Avatar
+GitHubBotAvatar.png

--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Deploy to Steam
-        uses: BoldestDungeon/steam-workshop-deploy@v1.0.1
+        uses: BoldestDungeon/steam-workshop-deploy@v2
         with:
           username: ${{ secrets.STEAM_USERNAME }}          
           configVdf: ${{ secrets.STEAM_CONFIG_VDF }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Don't allow the deployment directory to be tracked if it somehow happens to be in the development environment
+/deploy


### PR DESCRIPTION
Note: This PR requires the upstream changes from https://github.com/m00nl1ght-dev/steam-workshop-deploy to be merged into 
https://github.com/BoldestDungeon/steam-workshop-deploy, and for the updated fixes to be tagged `v2`

* Reduces overall size of the deployed mod artifact by ~766 Megabytes
* Resolves [GHSA-7j9v-72w9-ww6w](https://github.com/BoldestDungeon/wildermyth-drauven-pcs/security/advisories/GHSA-7j9v-72w9-ww6w)
* Resolves [GHSA-x6gv-2rvh-qmp6](https://github.com/BoldestDungeon/steam-workshop-deploy/security/advisories/GHSA-x6gv-2rvh-qmp6)
* You can now specify files and directories to exclude from the deployed mod artifact by including them in `.deployignore`
   * `.git/` directory is no longer included in deployed artifacts
   * `.github/` directory is no longer included in deployed artifacts
   * `.psd` files are no longer included in deployed artifacts
   * The github avatars are no longer included in deployed artifacts
