### PR TITLE
Update deployRelease.yml

### DIFF
--- a/.github/workflows/deployRelease.yml
+++ b/.github/workflows/deployRelease.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Deploy to Steam
-        uses: BoldestDungeon/steam-workshop-deploy@v2
+        uses: BoldestDungeon/steam-workshop-deploy@V2.0.0
         with:
           username: ${{ secrets.STEAM_USERNAME }}          
           configVdf: ${{ secrets.STEAM_CONFIG_VDF }}


### PR DESCRIPTION
Use correct version tag for steam workshop deploy workflow.

The tag created was named `V2.0.0` instead of the expected `v2`. This updates the workflow to use the actual tag that was created (`V2.0.0`)