### PR TITLE
ISSUE-683: Fix for combat difficulty modifiers going higher than 1

### DIFF
--- a/assets/data/effects/human/applyDifficultyModifiers.json
+++ b/assets/data/effects/human/applyDifficultyModifiers.json
@@ -22,7 +22,8 @@
         "class": "Aspects",
         "target": "self",
         "removeAspects": ["statModifier_combatDifficulty_10", "statModifier_combatDifficulty_default", "statModifier_combatDifficulty_30"],
-        "addAspects": [ {"id": "statModifier_combatDifficulty_1"}]
+        "addAspects": [ {"id": "statModifier_combatDifficulty_1", "value": 1}],
+        "merge": "replace"
       },
       "onFail": {
         "class": "Test",
@@ -33,7 +34,8 @@
           "class": "Aspects",
           "target": "self",
           "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_default", "statModifier_combatDifficulty_30"],
-          "addAspects": [ {"id": "statModifier_combatDifficulty_10"}]
+          "addAspects": [ {"id": "statModifier_combatDifficulty_10", "value": 1}],
+          "merge": "replace"
         },
         "onFail": {
           "class": "Test",
@@ -44,7 +46,8 @@
             "class": "Aspects",
             "target": "self",
             "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_10", "statModifier_combatDifficulty_default"],
-            "addAspects": [ {"id": "statModifier_combatDifficulty_30"}]
+            "addAspects": [ {"id": "statModifier_combatDifficulty_30", "value": 1}],
+            "merge": "replace"
           },
           "onFail": {
             "class": "Test",
@@ -55,7 +58,8 @@
               "class": "Aspects",
               "target": "self",
               "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_10", "statModifier_combatDifficulty_30"],
-              "addAspects": [ {"id": "statModifier_combatDifficulty_default"}]
+              "addAspects": [ {"id": "statModifier_combatDifficulty_default", "value": 1}],
+              "merge": "replace"
             }
           }
         }


### PR DESCRIPTION
* A character was reportedly getting the `adventurer` difficulty modifier applied multiple times, resulting in multiple applications of the stat boosts
* Using `replace` instead of the default `add` should prevent the problem from happening in the future

Closes #683