### PR TITLE
ISSUE-683: Fix for combat difficulty modifiers going higher than 1

### DIFF
--- a/assets/data/effects/human/applyDifficultyModifiers.json
+++ b/assets/data/effects/human/applyDifficultyModifiers.json
@@ -1,65 +1,92 @@
 {
-  "id": "applyDifficultyModifiers",
-  "info": { 
-    "dataVersion": 1, 
-    "sourceFile": "human/applyDifficultyModifiers",
-    "author": "Ironskink",
-    "STUB": "Checks current combat difficulty level and applies the appropriate stat modifiers" 
-  },
-  "type": "BRANCH",
-  "targets": [
-    {
-      "template": "SELF"
-    }
-  ],
-  "outcomes": [
-    {
-      "class": "Test",
-      "value": "MOD_ACTIVE.combatDifficulty_1 - statModifier_combatDifficulty_1",
-      "target": "self",
-      "threshold": "1",
-      "onPass": {
-        "class": "Aspects",
-        "target": "self",
-        "removeAspects": ["statModifier_combatDifficulty_10", "statModifier_combatDifficulty_default", "statModifier_combatDifficulty_30"],
-        "addAspects": [ {"id": "statModifier_combatDifficulty_1"}]
-      },
-      "onFail": {
-        "class": "Test",
-        "value": "MOD_ACTIVE.combatDifficulty_10 - statModifier_combatDifficulty_10",
-        "target": "self",
-        "threshold": "1",
-        "onPass": {
-          "class": "Aspects",
-          "target": "self",
-          "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_default", "statModifier_combatDifficulty_30"],
-          "addAspects": [ {"id": "statModifier_combatDifficulty_10"}]
-        },
-        "onFail": {
-          "class": "Test",
-          "value": "MOD_ACTIVE.combatDifficulty_30 - statModifier_combatDifficulty_30",
-          "target": "self",
-          "threshold": "1",
-          "onPass": {
-            "class": "Aspects",
-            "target": "self",
-            "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_10", "statModifier_combatDifficulty_default"],
-            "addAspects": [ {"id": "statModifier_combatDifficulty_30"}]
-          },
-          "onFail": {
-            "class": "Test",
-            "value": "1 - (MOD_ACTIVE.combatDifficulty_1 + MOD_ACTIVE.combatDifficulty_10 + MOD_ACTIVE.combatDifficulty_30) - statModifier_combatDifficulty_default",
-            "target": "self",
-            "threshold": "1",
-            "onPass": {
-              "class": "Aspects",
-              "target": "self",
-              "removeAspects": ["statModifier_combatDifficulty_1", "statModifier_combatDifficulty_10", "statModifier_combatDifficulty_30"],
-              "addAspects": [ {"id": "statModifier_combatDifficulty_default"}]
-            }
-          }
-        }
-      }
-    }
-  ]
+"id": "applyDifficultyModifiers",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "human/applyDifficultyModifiers",
+	"modId": "wildermyth-drauven-pcs",
+	"author": "Ironskink",
+	"STUB": "Checks current combat difficulty level and applies the appropriate stat modifiers"
+},
+"type": "BRANCH",
+"targets": [
+	{ "template": "SELF" }
+],
+"outcomes": [
+	{
+		"class": "Test",
+		"target": "self",
+		"value": "MOD_ACTIVE.combatDifficulty_1-statModifier_combatDifficulty_1",
+		"threshold": "1",
+		"onPass": {
+			"class": "Aspects",
+			"target": "self",
+			"addAspects": [
+				{ "id": "statModifier_combatDifficulty_1", "value": "1", "merge": "replace" }
+			],
+			"removeAspects": [
+				"statModifier_combatDifficulty_10",
+				"statModifier_combatDifficulty_default",
+				"statModifier_combatDifficulty_30"
+			]
+		},
+		"onFail": {
+			"class": "Test",
+			"target": "self",
+			"value": "MOD_ACTIVE.combatDifficulty_10-statModifier_combatDifficulty_10",
+			"threshold": "1",
+			"onPass": {
+				"class": "Aspects",
+				"target": "self",
+				"addAspects": [
+					{ "id": "statModifier_combatDifficulty_10", "value": "1", "merge": "replace" }
+				],
+				"removeAspects": [
+					"statModifier_combatDifficulty_1",
+					"statModifier_combatDifficulty_default",
+					"statModifier_combatDifficulty_30"
+				]
+			},
+			"onFail": {
+				"class": "Test",
+				"target": "self",
+				"value": "MOD_ACTIVE.combatDifficulty_30-statModifier_combatDifficulty_30",
+				"threshold": "1",
+				"onPass": {
+					"class": "Aspects",
+					"target": "self",
+					"addAspects": [
+						{ "id": "statModifier_combatDifficulty_30", "value": "1", "merge": "replace" }
+					],
+					"removeAspects": [
+						"statModifier_combatDifficulty_1",
+						"statModifier_combatDifficulty_10",
+						"statModifier_combatDifficulty_default"
+					]
+				},
+				"onFail": {
+					"class": "Test",
+					"target": "self",
+					"value": "(1-((MOD_ACTIVE.combatDifficulty_1+MOD_ACTIVE.combatDifficulty_10)+MOD_ACTIVE.combatDifficulty_30))-statModifier_combatDifficulty_default",
+					"threshold": "1",
+					"onPass": {
+						"class": "Aspects",
+						"target": "self",
+						"addAspects": [
+							{
+								"id": "statModifier_combatDifficulty_default",
+								"value": "1",
+								"merge": "replace"
+							}
+						],
+						"removeAspects": [
+							"statModifier_combatDifficulty_1",
+							"statModifier_combatDifficulty_10",
+							"statModifier_combatDifficulty_30"
+						]
+					}
+				}
+			}
+		}
+	}
+]
 }


### PR DESCRIPTION
* A character was reportedly getting the `adventurer` difficulty modifier applied multiple times, resulting in multiple applications of the stat boosts
* Using `replace` instead of the default `add` should prevent the problem from happening in the future

Closes #683