### PR TITLE
ISSUE-687: Give way for players to fix stats when migration did not run properly

### DIFF
--- a/assets/data/aspects/races.json
+++ b/assets/data/aspects/races.json
@@ -4,7 +4,8 @@
 	"id": "drauven_pc",
 	"effects": [
 		"drauven_aging",
-		"migrateDrauvenAspects"
+		"migrateDrauvenAspects",
+		"manualMigrateDrauvenAspects"
 	],
 	"stats": {
 		"ARMOR": 0,

--- a/assets/data/effects/migrations/Issue-498_DrauvenAspectsMigrationManual.json
+++ b/assets/data/effects/migrations/Issue-498_DrauvenAspectsMigrationManual.json
@@ -1,0 +1,49 @@
+{
+"id": "manualMigrateDrauvenAspects",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "migrations/Issue-498_DrauvenAspectsMigrationManual",
+	"modId": "wildermyth-drauven-pcs",
+	"author": "Ironskink",
+	"STUB": "Breaks the 'human' aspect into multiple aspects for each separate area of concern."
+},
+"type": "ABILITY",
+"verb": "MANEUVER",
+"ability": {
+	"icon": "starheart",
+	"priority": "1",
+	"onlyShowIfPossibleInCharacterSheet": true
+},
+"targets": [
+	{
+		"template": "SELF",
+		"aspectValues": [
+			{ "id": "drauvenInterfusionRecipes", "forbidden": true },
+			{ "id": "issue498DrauvenMigrationRan", "forbidden": true }
+		]
+	}
+],
+"outcomes": [
+	{
+		"class": "AddHistory",
+		"target": "self",
+		"inlineHistory": {
+			"id": "humanAspectsMigration",
+			"associatedAspects": [
+				"drauvenInterfusionRecipes",
+				"heroicActions",
+				"drauvenDifficultyModifiers",
+				"issue498DrauvenMigrationRan"
+			],
+			"persistOverLegacy": "never",
+			"showInSummary": false,
+			"removeAspects": [ "trueHuman", "humanBaseStats", "humanVoice", "basicInterfusionRecipes" ]
+		}
+	},
+	{
+		"class": "BranchAbility",
+		"target": "self",
+		"branchAbility": "applyDifficultyModifiers"
+	}
+]
+}

--- a/assets/data/effects/migrations/Issue-498_HumanAspectsMigrationManual.json
+++ b/assets/data/effects/migrations/Issue-498_HumanAspectsMigrationManual.json
@@ -1,0 +1,55 @@
+{
+"id": "manualHumanAspectMigrate",
+"info": {
+	"dataVersion": 1,
+	"sourceFile": "migrations/Issue-498_HumanAspectsMigrationManual",
+	"modId": "wildermyth-drauven-pcs",
+	"author": "Ironskink",
+	"STUB": "Breaks the 'human' aspect into multiple aspects for each separate area of concern."
+},
+"type": "ABILITY",
+"verb": "MANEUVER",
+"ability": {
+	"icon": "starheart",
+	"priority": "1",
+	"onlyShowIfPossibleInCharacterSheet": true
+},
+"targets": [
+	{
+		"template": "SELF",
+		"aspectValues": [
+			{ "id": "nonhuman", "forbidden": true },
+			{ "id": "humanBaseStats", "forbidden": true },
+			{ "id": "humanVoice", "forbidden": true },
+			{ "id": "heroicActions", "forbidden": true },
+			{ "id": "basicInterfusionRecipes", "forbidden": true },
+			{ "id": "issue498HumanMigrationRan", "forbidden": true }
+		]
+	}
+],
+"outcomes": [
+	{
+		"class": "AddHistory",
+		"target": "self",
+		"inlineHistory": {
+			"id": "humanAspectsMigration",
+			"associatedAspects": [
+				"humanBaseStats",
+				"humanVoice",
+				"heroicActions",
+				"trueHuman",
+				"basicInterfusionRecipes",
+				"usesDifficultyModifiers",
+				"issue498HumanMigrationRan"
+			],
+			"persistOverLegacy": "never",
+			"showInSummary": false
+		}
+	},
+	{
+		"class": "BranchAbility",
+		"target": "self",
+		"branchAbility": "applyDifficultyModifiers"
+	}
+]
+}

--- a/assets/data/modInjections/aspects/humans.json
+++ b/assets/data/modInjections/aspects/humans.json
@@ -5,7 +5,7 @@
 		"jsonPath": "human/effects",
 		"type": "stringList",
 		"addJson": { "class": "java.lang.String", "value": "" },
-		"addStrings": [ "migrateHumanAspects" ],
+		"addStrings": [ "migrateHumanAspects", "manualHumanAspectMigrate" ],
 		"remove": [
 			"run",
 			"openDoor",

--- a/assets/text/effects/migrations/Issue-498_DrauvenAspectsMigrationManual.properties
+++ b/assets/text/effects/migrations/Issue-498_DrauvenAspectsMigrationManual.properties
@@ -1,0 +1,3 @@
+#suppress inspection "UnusedProperty" for whole file
+.blurb=The Drauven PCs mod has updated how Human and Drauven stats are separated, and this character is missing some important aspects! Run this to restore your hero's stats!
+.name=FIX STATS

--- a/assets/text/effects/migrations/Issue-498_HumanAspectsMigrationManual.properties
+++ b/assets/text/effects/migrations/Issue-498_HumanAspectsMigrationManual.properties
@@ -1,0 +1,3 @@
+#suppress inspection "UnusedProperty" for whole file
+.blurb=The Drauven PCs mod has updated how Human and Drauven stats are separated, and this character is missing some important aspects! Run this to restore your hero's stats!
+.name=FIX STATS


### PR DESCRIPTION
* Mid-combat saves cannot easily trigger an `effect` to give everybody the new stat distribution, a new migration effect is added that gives a button to trigger the update if a character is lacking the required aspects

Closes #687 