### PR TITLE
ISSUE-689: Fix for legacy heroes dropping gear on recruit

### DIFF
--- a/assets/data/effects/migrations/Issue-631_Torso_migration.json
+++ b/assets/data/effects/migrations/Issue-631_Torso_migration.json
@@ -7,7 +7,7 @@
     "author": "Ironskink",
     "STUB": "Updates characters to use the updated 'species' piece instead of the 'torso' slot, allowing characters to get torso transformations"
   },
-  "type": "ABILITIES_CHANGED",
+  "type": "LEVEL_START",
   "targets": [
     {
       "template": "SELF",


### PR DESCRIPTION
* Fixes a bug where legacy heroes with the legacy Torso theme part would drop all gear if recruited from legacy mid-campaign

closes #689